### PR TITLE
Removed contractingProcesses/summary/ocid as duplicate OCID

### DIFF
--- a/docs/examples/example.json
+++ b/docs/examples/example.json
@@ -292,7 +292,6 @@
         {
           "id": "ocds-a1b1c1-a410a80d-adc8-11e6-9901-0019b9f3037b",
           "summary": {
-            "ocid": "ocds-a1b1c1-a410a80d-adc8-11e6-9901-0019b9f3037b",
             "externalReference": "2016-SMP-M75-J4_J5-design",
             "nature": [
               "design"
@@ -362,7 +361,6 @@
         {
           "id": "ocds-a1b1c1-370ad85a-097f-4b8c-adf8-09d840c7c48b",
           "summary": {
-            "ocid": "ocds-a1b1c1-370ad85a-097f-4b8c-adf8-09d840c7c48b",
             "externalReference": "2016-SMP-M75-J4_J5-supervision",
             "nature": [
               "supervision"
@@ -447,7 +445,6 @@
         {
           "id": "ocds-a1b1c1-c9b14c18-adc8-11e6-9901-0019b9f3037b",
           "summary": {
-            "ocid": "ocds-a1b1c1-c9b14c18-adc8-11e6-9901-0019b9f3037b",
             "externalReference": "2016-SMP-M75-J4_J5-construction",
             "nature": [
               "construction"

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -12,6 +12,7 @@
 * [#141](https://github.com/open-contracting/infrastructure/issues/141) - clarify that `contractingProcesses/summary/description` is for the contract's *initial* scope of work
 * [#141](https://github.com/open-contracting/infrastructure/issues/141) - remove incorrect guidance about other fields from `contractingProcesses/summary/modifications`
 * [#160](https://github.com/open-contracting/infrastructure/issues/160) - describe the components of `project/id`, and link to guidance
+* [#161](https://github.com/open-contracting/infrastructure/issues/161) - removed `contractingProcesses/summary/ocid` because it duplicates `contractingProcesses/id`
 
 ### Codelists
 

--- a/schema/project-level/project-schema.json
+++ b/schema/project-level/project-schema.json
@@ -224,11 +224,6 @@
       "title": "Summary",
       "description": "Summary information about a contracting process and any modifications to it.\n\n Summary information can be manually entered and the `modifications` list can be used to manually record a log of changes, with the date and details of each modification.\n\n Where OCDS data is available, most summary fields can be derived from OCDS releases, although the exact method to derive data may vary between implementations; and modifications may be identified by comparing a new release to previous releases to check for relevant changes, with the release identifier recorded in `modifications`.",
       "properties": {
-        "ocid": {
-          "title": "Open Contracting Identifier",
-          "description": "If this contracting process has been assigned an Open Contracting Identifier (OCID) by an external platform (e.g. national procurement system), that OCID must be recorded here. Otherwise this field should be omitted.",
-          "type": "string"
-        },
         "externalReference": {
           "title": "External reference",
           "description": "If this contracting process is identified by some external reference number it may be recorded here.",


### PR DESCRIPTION
fixes #161 - contractingProcesses/summary/ocid removed in schema, example file, changelog updated