### PR TITLE
124 update prefix guidance

### DIFF
--- a/docs/guidance/identifiers.md
+++ b/docs/guidance/identifiers.md
@@ -37,13 +37,15 @@ The `planning/budget/projectID` field in OCDS should **not** be used to disclose
 
 ## Globally unique project identifiers
 
-Project identifiers in OC4IDS should be globally unique; this means that, across the data of all OC4IDS publishers, each project identifier refers to exactly one infrastructure project.
+Project identifiers in OC4IDS should be globally unique; this means that, across all the data of all OC4IDS publishers, each project identifier refers to exactly one infrastructure project.
 
-If local project identifiers are available in existing systems or data, these should be re-used to create globally unique project identifiers for use in OC4IDS; otherwise, if local project identifiers are not available, publishers may assign local identifiers to projects in the systems used to generate OC4IDS data.
+If local project identifiers are available in existing systems or data, these should be re-used to create globally unique project identifiers for use in OC4IDS. Otherwise, if local project identifiers are not available, publishers may assign local identifiers to projects in the new systems used to generate OC4IDS data.
 
-To make local project identifiers globally unique for use in OC4IDS, the OC4IDS Helpdesk assigns a project identifier prefix that publishers must add to local project identifiers, using the following identifier structure: `[project identifier prefix]-[local project identifier]`.
+To make local project identifiers globally unique for use in OC4IDS, a publisher requests a project identifier prefix from the [OC4IDS Helpdesk](mailto:data@open-contracting.org). The publisher must then use the assigned prefix in all its project identifiers, according to following structure: `[project identifier prefix]-[local project identifier]`.
 
-Project identifier prefixes establish an identifier series and the same prefix is used for all identifiers in a series. For example, the prefix `oc4ids-qu8r7p`, assigned by the OC4IDS Helpdesk, will be added to all the project identifiers from the SISOCS system developed by CoST Honduras.
+For example: CoST Honduras requests a project identifier prefix from the OC4IDS Helpdesk. The OC4IDS Helpdesk assigns the randomly-generated prefix `oc4ids-qu8r7p`. CoST Honduras then creates globally unique project identifiers, by combining its assigned prefix with each local project identifier from its SISOCS system.
+
+Project identifier prefixes are typically unique to each publisher. However, multiple publishers in the same jurisdiction can collaboratively decide to use the same project identifier prefix: for example, if multiple agencies are independently responsible for different projects. As such, the prefix serves to identify a series of infrastructure projects (to which many publishers can contribute), rather than to identify one publisher.
 
 ```eval_rst
 .. admonition:: Request a project identifier prefix

--- a/docs/guidance/identifiers.md
+++ b/docs/guidance/identifiers.md
@@ -33,7 +33,7 @@ There are different approaches to including project identifiers in contracting d
 
 In OCDS, the identifier for the individual infrastructure project to which a contracting process is related should be disclosed using the `planning/project/id` field, introduced in the [Budget and Projects extension](https://extensions.open-contracting.org/en/extensions/budget_project/).
 
-The `planning/budget/projectID` field in OCDS should **not** be used to disclose the identifier for an individual infrastructure project. This field is used to disclose the identifier for a project in the national budget, which might include multiple infrastructure projects, to which the contracting process is related.
+The `planning/budget/projectID` field in OCDS should **not** be used to disclose the identifier for an individual infrastructure project. This field is used to disclose the identifier for a project in the national budget to which the contracting process is related. Since projects in the national budget might include many individual infrastructure projects, it is necessary to disclose these identifiers separately.
 
 ## Globally unique project identifiers
 

--- a/docs/guidance/identifiers.md
+++ b/docs/guidance/identifiers.md
@@ -43,6 +43,8 @@ If local project identifiers are available in existing systems or data, these sh
 
 To make local project identifiers globally unique for use in OC4IDS, the OC4IDS Helpdesk assigns a project identifier prefix that publishers must add to local project identifiers, using the following identifier structure: `[project identifier prefix]-[local project identifier]`.
 
+Project identifier prefixes establish an identifier series and the same prefix is used for all identifiers in a series. For example, the prefix `oc4ids-qu8r7p`, assigned by the OC4IDS Helpdesk, will be added to all the project identifiers from the SISOCS system developed by CoST Honduras.
+
 ```eval_rst
 .. admonition:: Request a project identifier prefix
     :class: tip

--- a/docs/guidance/identifiers.md
+++ b/docs/guidance/identifiers.md
@@ -33,7 +33,7 @@ There are different approaches to including project identifiers in contracting d
 
 In OCDS, the identifier for the individual infrastructure project to which a contracting process is related should be disclosed using the `planning/project/id` field, introduced in the [Budget and Projects extension](https://extensions.open-contracting.org/en/extensions/budget_project/).
 
-The `planning/budget/projectID` field in OCDS should **not** be used to disclose the identifier for an individual infrastructure project. This field is used to disclose the identifier for a project in the national budget, which might include multiple infrastructure projects to which the contracting process is related.
+The `planning/budget/projectID` field in OCDS should **not** be used to disclose the identifier for an individual infrastructure project. This field is used to disclose the identifier for a project in the national budget, which might include multiple infrastructure projects, to which the contracting process is related.
 
 ## Globally unique project identifiers
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -10,6 +10,7 @@
 * [#143](https://github.com/open-contracting/infrastructure/issues/143) - update worked example page to describe project package, use non-normative keywords, and edit for clarity.
 * [#143](https://github.com/open-contracting/infrastructure/issues/143) - add data user guide page.
 * [#146](https://github.com/open-contracting/infrastructure/issues/146) - add 'publicAuthority' role to example file.
+* [#124](https://github.com/open-contracting/infrastructure/issues/124) - clarify guidance on project identifier prefixes.
 
 ### Schema
 


### PR DESCRIPTION
Closes #124 

Also adds a missing comma to the guidance on project identifiers in OCDS, added in https://github.com/open-contracting/infrastructure/pull/166, to make the meaning clear.