### PR TITLE
Restore Travis tests. Add missing value to projectType enum.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ install:
   - curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
   - pip install -r requirements.txt
 script:
-#  - curl -s -S --retry 3 $BASEDIR/tests/script.sh | bash -
+  - curl -s -S --retry 3 $BASEDIR/tests/script.sh | bash -
   - make

--- a/schema/project-level/project-schema.json
+++ b/schema/project-level/project-schema.json
@@ -82,7 +82,8 @@
       "enum": [
         "construction",
         "rehabilitation",
-        "replacement"
+        "replacement",
+        "expansion"
       ],
       "codelist": "projectType.csv",
       "openCodelist": false


### PR DESCRIPTION
closes #155

I fixed standard-maintenance-scripts to get this to work.