### PR TITLE
Update borrow schema.py

### DIFF
--- a/schema/borrow-schema.py
+++ b/schema/borrow-schema.py
@@ -18,6 +18,7 @@ of such fields, and instead leaves this up to the editor.
 import csv
 import json
 import os
+from collections import OrderedDict
 import re
 import sys
 from copy import deepcopy
@@ -29,7 +30,7 @@ ppp_base_url = 'https://standard.open-contracting.org/profiles/ppp/latest/en/_st
 ocds_base_url = 'https://standard.open-contracting.org/1.1/en/'
 schema_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'project-level')
 codelists_dir = os.path.join(schema_dir, 'codelists')
-ppp_schema = requests.get(ppp_base_url + 'release-schema.json').json()
+ppp_schema = requests.get(ppp_base_url + 'release-schema.json').json(object_pairs_hook=OrderedDict)
 
 
 def csv_reader(url):
@@ -128,9 +129,8 @@ def compare(actual, infra_list, ocds_list, prefix, suffix):
         sys.exit('{prefix} is missing {items}: remove from infra_{suffix} in borrow-schema.py?'.format(
             items=', '.join(removed), prefix=prefix, suffix=suffix))
 
-
 with open(os.path.join(schema_dir, 'project-schema.json')) as f:
-    schema = json.load(f)
+    schema = json.load(f, object_pairs_hook=OrderedDict)
 
 infra_codelists = {
     'contractingProcessStatus.csv',
@@ -139,6 +139,8 @@ infra_codelists = {
     'projectSector.csv',
     'projectStatus.csv',
     'projectType.csv',
+    'relatedProjectScheme.csv',
+    'relatedProject.csv'
 }
 ocds_codelists = {
     'currency.csv',
@@ -157,6 +159,7 @@ infra_definitions = {
     'ContractingProcessSummary',  # Similar to OCDS release, and includes direction on how to populate from OCDS data.
     'LinkedRelease',  # Similar to linked release in OCDS record package.
     'Modification',
+    'RelatedProject' # Similar to relatedProcess in OCDS
 }
 ocds_definitions = {
     'Period',
@@ -300,6 +303,8 @@ copy_def('Value')
 copy_def('Organization', {
     # Refer to project instead of contracting process.
     ('properties', 'roles', 'description'): lambda s: s.replace('contracting process', 'project'),
+    # Link to infrastructure codelist instead of PPP codelist
+    ('properties', 'roles', 'description'): lambda s: s.replace('profiles/ppp/latest/en/', 'infrastructure/{{version}}/{{lang}}/'),
 })
 # Remove unneeded extensions and details from Organization.
 del(schema['definitions']['Organization']['properties']['shareholders'])
@@ -317,7 +322,10 @@ copy_def('ContactPoint', {
 
 copy_def('BudgetBreakdown')
 
-copy_def('Document')
+copy_def('Document', {
+    # Link to infrastructure codelist instead of PPP codelist
+    ('properties', 'documentType', 'description'): lambda s: s.replace('profiles/ppp/latest/en/', 'infrastructure/{{version}}/{{lang}}/'),
+})
 # noqa: Original from standard:                                                 "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document.",
 schema['definitions']['Document']['properties']['description']['description'] = "Where a link to a full document is provided, the description should provide a 1 - 3 paragraph summary of the information the document contains, and the `pageStart` field should be used to make sure readers can find the correct section of the document containing more information. Where there is no linked document available, the description field may contain all the information required by the current `documentType`. \n\nLine breaks in text (represented in JSON using `\\n\\n`) must be respected by systems displaying this information, and systems may also support basic HTML tags (H1-H6, B, I, U, strong, A and optionally IMG) or [markdown syntax](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for formatting. "  # noqa
 # noqa: Original from standard:                                         " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type."

--- a/schema/borrow-schema.py
+++ b/schema/borrow-schema.py
@@ -18,9 +18,9 @@ of such fields, and instead leaves this up to the editor.
 import csv
 import json
 import os
-from collections import OrderedDict
 import re
 import sys
+from collections import OrderedDict
 from copy import deepcopy
 from io import StringIO
 
@@ -128,6 +128,7 @@ def compare(actual, infra_list, ocds_list, prefix, suffix):
     if removed:
         sys.exit('{prefix} is missing {items}: remove from infra_{suffix} in borrow-schema.py?'.format(
             items=', '.join(removed), prefix=prefix, suffix=suffix))
+
 
 with open(os.path.join(schema_dir, 'project-schema.json')) as f:
     schema = json.load(f, object_pairs_hook=OrderedDict)
@@ -301,10 +302,8 @@ schema['definitions']['Location']['required'] = ['id']
 copy_def('Value')
 
 copy_def('Organization', {
-    # Refer to project instead of contracting process.
-    ('properties', 'roles', 'description'): lambda s: s.replace('contracting process', 'project'),
-    # Link to infrastructure codelist instead of PPP codelist
-    ('properties', 'roles', 'description'): lambda s: s.replace('profiles/ppp/latest/en/', 'infrastructure/{{version}}/{{lang}}/'),
+    # Refer to project instead of contracting process, link to infrastructure codelist instead of PPP codelist.
+    ('properties', 'roles', 'description'): lambda s: s.replace('contracting process', 'project').replace('profiles/ppp/latest/en/', 'infrastructure/{{version}}/{{lang}}/')
 })
 # Remove unneeded extensions and details from Organization.
 del(schema['definitions']['Organization']['properties']['shareholders'])

--- a/schema/project-level/codelists/partyRole.csv
+++ b/schema/project-level/codelists/partyRole.csv
@@ -9,5 +9,5 @@ payer,Payer,A party making a payment from a transaction.,OCDS
 payee,Payee,A party in receipt of a payment from a transaction.,OCDS
 reviewBody,Review body,A party responsible for the review of this procurement process. This party often has a role in any challenges made to the contract award.,OCDS
 interestedParty,Interested party,"A party that has expressed an interest in the contracting process: for example, by purchasing tender documents or submitting clarification questions.",OCDS
-publicAuthority,Public Authority,"The entity responsible for developing the infrastructure assets and/or delivering the public services in this project.",OC4IDS
+publicAuthority,Public Authority,The entity responsible for developing the infrastructure assets and/or delivering the public services in this project.,OC4IDS
 administrativeEntity,Administrative Entity,The entity responsible for contract administration.,OC4IDS

--- a/schema/project-level/project-schema.json
+++ b/schema/project-level/project-schema.json
@@ -684,8 +684,7 @@
                 "type": [
                   "string"
                 ]
-              },
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -1077,7 +1076,7 @@
         },
         "roles": {
           "title": "Party roles",
-          "description": "The party's role(s) in the project, using the open [partyRole](https://standard.open-contracting.org/profiles/ppp/latest/en/reference/codelists/#partyrole) codelist.",
+          "description": "The party's role(s) in the contracting process, using the open [partyRole](https://standard.open-contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#partyrole) codelist.",
           "type": [
             "array"
           ],
@@ -1085,8 +1084,7 @@
             "type": "string"
           },
           "codelist": "partyRole.csv",
-          "openCodelist": true,
-          "uniqueItems": true
+          "openCodelist": true
         }
       }
     },
@@ -1257,7 +1255,7 @@
         },
         "documentType": {
           "title": "Document type",
-          "description": "A classification of the document described, using the open [documentType](https://standard.open-contracting.org/profiles/ppp/latest/en/reference/codelists/#documenttype) codelist.",
+          "description": "A classification of the document described, using the open [documentType](https://standard.open-contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#documenttype) codelist.",
           "type": [
             "string"
           ],

--- a/schema/project-level/project-schema.json
+++ b/schema/project-level/project-schema.json
@@ -684,7 +684,8 @@
                 "type": [
                   "string"
                 ]
-              }
+              },
+              "uniqueItems": true
             }
           }
         },
@@ -1084,7 +1085,8 @@
             "type": "string"
           },
           "codelist": "partyRole.csv",
-          "openCodelist": true
+          "openCodelist": true,
+          "uniqueItems": true
         }
       }
     },

--- a/schema/project-level/project-schema.json
+++ b/schema/project-level/project-schema.json
@@ -1076,7 +1076,7 @@
         },
         "roles": {
           "title": "Party roles",
-          "description": "The party's role(s) in the contracting process, using the open [partyRole](https://standard.open-contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#partyrole) codelist.",
+          "description": "The party's role(s) in the project, using the open [partyRole](https://standard.open-contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#partyrole) codelist.",
           "type": [
             "array"
           ],


### PR DESCRIPTION
Closes #221 

This PR updates `borrow-schema.py` to:

* replace links in `party/roles` and `documents/documentType` to PPP codelists with links to the OC4IDS codelists.

* revert some changes from https://github.com/open-contracting/infrastructure/commit/d75b7ce56f5b2c581e8ffbbf88f7c11e1b0c5f18 which broke `borrow-schema.py` because `Dict` doesn't have the `move_to_end` method used in the script.

* add the new relatedProject codelist and definition

It also commits the changes from running the script, which fixes the incorrect links.

Edit: I'm not sure why the tests are failing.