### PR TITLE
Pull translations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,141 @@
+[main]
+host = https://www.transifex.com
+
+[oc4ids-09.support]
+file_filter = locale/<lang>/LC_MESSAGES/support.po
+source_file = build/locale/support.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.infrastructureschema]
+file_filter = locale/<lang>/LC_MESSAGES/infrastructureschema.po
+source_file = build/locale/infrastructureschema.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.sphinx]
+file_filter = locale/<lang>/LC_MESSAGES/sphinx.po
+source_file = build/locale/sphinx.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.infrastructurecodelists]
+file_filter = locale/<lang>/LC_MESSAGES/infrastructurecodelists.po
+source_file = build/locale/infrastructurecodelists.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.index]
+file_filter = locale/<lang>/LC_MESSAGES/index.po
+source_file = build/locale/index.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.404]
+file_filter = locale/<lang>/LC_MESSAGES/404.po
+source_file = build/locale/404.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.about]
+file_filter = locale/<lang>/LC_MESSAGES/about.po
+source_file = build/locale/about.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.cost--index]
+file_filter = locale/<lang>/LC_MESSAGES/cost/index.po
+source_file = build/locale/cost/index.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--publishing]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/publishing.po
+source_file = build/locale/guidance/publishing.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--evaluating]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/evaluating.po
+source_file = build/locale/guidance/evaluating.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--example]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/example.po
+source_file = build/locale/guidance/example.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--using]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/using.po
+source_file = build/locale/guidance/using.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--data_user_guide]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/data_user_guide.po
+source_file = build/locale/guidance/data_user_guide.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--index]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/index.po
+source_file = build/locale/guidance/index.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.guidance--identifiers]
+file_filter = locale/<lang>/LC_MESSAGES/guidance/identifiers.po
+source_file = build/locale/guidance/identifiers.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.projects--index]
+file_filter = locale/<lang>/LC_MESSAGES/projects/index.po
+source_file = build/locale/projects/index.pot
+source_lang = en
+type = PO
+
+[oc4ids-09._static--docson--README]
+file_filter = locale/<lang>/LC_MESSAGES/_static/docson/README.po
+source_file = build/locale/_static/docson/README.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--schema]
+file_filter = locale/<lang>/LC_MESSAGES/reference/schema.po
+source_file = build/locale/reference/schema.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--browser]
+file_filter = locale/<lang>/LC_MESSAGES/reference/browser.po
+source_file = build/locale/reference/browser.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--changelog]
+file_filter = locale/<lang>/LC_MESSAGES/reference/changelog.po
+source_file = build/locale/reference/changelog.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--package]
+file_filter = locale/<lang>/LC_MESSAGES/reference/package.po
+source_file = build/locale/reference/package.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--index]
+file_filter = locale/<lang>/LC_MESSAGES/reference/index.po
+source_file = build/locale/reference/index.pot
+source_lang = en
+type = PO
+
+[oc4ids-09.reference--codelists]
+file_filter = locale/<lang>/LC_MESSAGES/reference/codelists.po
+source_file = build/locale/reference/codelists.pot
+source_lang = en
+type = PO
+

--- a/.tx/config
+++ b/.tx/config
@@ -7,6 +7,12 @@ source_file = build/locale/support.pot
 source_lang = en
 type = PO
 
+[oc4ids-09.infrastructuremappings]
+file_filter = locale/<lang>/LC_MESSAGES/infrastructuremappings.po
+source_file = build/locale/infrastructuremappings.pot
+source_lang = en
+type = PO
+
 [oc4ids-09.infrastructureschema]
 file_filter = locale/<lang>/LC_MESSAGES/infrastructureschema.po
 source_file = build/locale/infrastructureschema.pot

--- a/babel_ocds_mapping.cfg
+++ b/babel_ocds_mapping.cfg
@@ -1,0 +1,2 @@
+[ocds_codelist: mapping/*.csv]
+headers = Mapping to OC for Infrastructure,Mapping from OCDS

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -16,6 +16,12 @@
 </ul>
 {% endblock %}
 
+{% block language_options %}
+            <option>Language</option>
+            <option value="en">English</option>
+            <option value="es">Español</option>
+{% endblock %}
+
 {% block version_options %}
 <!--#include virtual="/includes/version-options-infrastructure.html" -->
 {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,10 +154,3 @@ def setup(app):
         (glob(str(basedir / 'mapping' / '*.csv')), project_build_dir, mapping_domain),
         (glob(str(basedir / 'mapping' / '*.csv')), language_dir, mapping_domain),
     ], localedir, language, mapping_headers, version=branch)
-
-    # Copy our mapping files as well. This currently does not perform translation, which would need to be added.
-    # for filename in glob(str(basedir / 'mapping' / '*.csv')):
-    #    with open(filename) as f:
-    #        mapping_file = f.read()
-    #    with open(language_dir / os.path.basename(filename), 'w') as f:
-    #        f.write(mapping_file)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,11 @@ def setup(app):
 
     language = app.config.overrides.get('language', 'en')
 
-    headers = ['Title', 'Description', 'Extension']
+    # Headers for columns to translate in codelist CSVs
+    codelist_headers = ['Title', 'Description', 'Extension']
+    # Headers for columns to translate in mapping CSVs
+    mapping_headers = ['Mapping to OC for Infrastructure','Mapping from OCDS']
+
     # The gettext domain for schema translations. Should match the domain in the `pybabel compile` command.
     schema_domain = '{}schema'.format(gettext_domain_prefix)
     # The gettext domain for codelist translations. Should match the domain in the `pybabel compile` command.
@@ -134,6 +138,7 @@ def setup(app):
 
     branch = os.getenv('TRAVIS_BRANCH', os.getenv('GITHUB_REF', 'latest').rsplit('/', 1)[-1])
 
+    # Translate schema and codelists
     translate([
         # The glob patterns in `babel_ocds_schema.cfg` should match these filenames.
         (glob(str(project_dir / '*-schema.json')), project_build_dir, schema_domain),
@@ -141,10 +146,14 @@ def setup(app):
         # The glob patterns in `babel_ocds_codelist.cfg` should match these.
         (glob(str(project_dir / 'codelists' / '*.csv')), project_build_dir / 'codelists', codelists_domain),
         (glob(str(project_dir / 'codelists' / '*.csv')), language_dir / 'codelists', codelists_domain),
+    ], localedir, language, codelist_headers, version=branch)
+
+    # Translate mapping CSVs
+    translate([
         # The glob patterns in `babel_ocds_mapping.cfg` should match these filenames.
         (glob(str(basedir / 'mapping' / '*.csv')), project_build_dir, mapping_domain),
         (glob(str(basedir / 'mapping' / '*.csv')), language_dir, mapping_domain),
-    ], localedir, language, headers, version=branch)
+    ], localedir, language, mapping_headers, version=branch)
 
     # Copy our mapping files as well. This currently does not perform translation, which would need to be added.
     # for filename in glob(str(basedir / 'mapping' / '*.csv')):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ def setup(app):
     # The gettext domain for codelist translations. Should match the domain in the `pybabel compile` command.
     codelists_domain = '{}codelists'.format(gettext_domain_prefix)
     # The gettext domain for mapping translations. Should match the domain in the `pybabel compile` command.
-    mapping_domain = '{}mapping.'.format(gettext_domain_prefix)
+    mapping_domain = '{}mappings'.format(gettext_domain_prefix)
 
     project_dir = basedir / 'schema' / 'project-level'
     project_build_dir = basedir / 'docs' / '_static' / 'project-level'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ locale_dirs = ['../locale/', os.path.join(standard_theme.get_html_theme_path(), 
 gettext_compact = False
 
 # The `DOMAIN_PREFIX` from `config.mk`.
-gettext_domain_prefix = '{}-'.format(profile_identifier)
+gettext_domain_prefix = '{}'.format(profile_identifier)
 
 # List the extension identifiers and versions that should be part of this profile. The extensions must be available in
 # the extension registry: https://github.com/open-contracting/extension_registry/blob/master/extension_versions.csv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,6 +125,8 @@ def setup(app):
     schema_domain = '{}schema'.format(gettext_domain_prefix)
     # The gettext domain for codelist translations. Should match the domain in the `pybabel compile` command.
     codelists_domain = '{}codelists'.format(gettext_domain_prefix)
+    # The gettext domain for mapping translations. Should match the domain in the `pybabel compile` command.
+    mapping_domain = '{}mapping.'.format(gettext_domain_prefix)
 
     project_dir = basedir / 'schema' / 'project-level'
     project_build_dir = basedir / 'docs' / '_static' / 'project-level'
@@ -139,11 +141,14 @@ def setup(app):
         # The glob patterns in `babel_ocds_codelist.cfg` should match these.
         (glob(str(project_dir / 'codelists' / '*.csv')), project_build_dir / 'codelists', codelists_domain),
         (glob(str(project_dir / 'codelists' / '*.csv')), language_dir / 'codelists', codelists_domain),
+        # The glob patterns in `babel_ocds_mapping.cfg` should match these filenames.
+        (glob(str(basedir / 'mapping' / '*.csv')), project_build_dir, mapping_domain),
+        (glob(str(basedir / 'mapping' / '*.csv')), language_dir, mapping_domain),
     ], localedir, language, headers, version=branch)
 
     # Copy our mapping files as well. This currently does not perform translation, which would need to be added.
-    for filename in glob(str(basedir / 'mapping' / '*.csv')):
-        with open(filename) as f:
-            mapping_file = f.read()
-        with open(language_dir / os.path.basename(filename), 'w') as f:
-            f.write(mapping_file)
+    # for filename in glob(str(basedir / 'mapping' / '*.csv')):
+    #    with open(filename) as f:
+    #        mapping_file = f.read()
+    #    with open(language_dir / os.path.basename(filename), 'w') as f:
+    #        f.write(mapping_file)

--- a/include/common.mk
+++ b/include/common.mk
@@ -39,6 +39,10 @@ extract_codelists: $(POT_DIR)
 extract_schema: $(POT_DIR)
 	pybabel extract -F babel_ocds_schema.cfg . -o $(POT_DIR)/$(DOMAIN_PREFIX)schema.pot
 
+.PHONY: extract_mappings
+extract_mappings: $(POT_DIR)
+	pybabel extract -F babel_ocds_mapping.cfg . -o $(POT_DIR)/$(DOMAIN_PREFIX)mappings.pot
+
 # The codelist CSV files and JSON Schema files must be present for the `csv-table-no-translate` and `jsonschema`
 # directives to succeed, but the contents of the files have no effect on the generated .pot files.
 # See http://www.sphinx-doc.org/en/stable/builders.html#sphinx.builders.gettext.MessageCatalogBuilder
@@ -47,7 +51,7 @@ extract_markdown: current_lang.en
 	sphinx-build -q -b gettext $(DOCS_DIR) $(POT_DIR)
 
 .PHONY: extract
-extract: extract_codelists extract_schema $(EXTRACT_TARGETS) extract_markdown clean_current_lang
+extract: extract_codelists extract_schema extract_mappings $(EXTRACT_TARGETS) extract_markdown clean_current_lang
 
 ### Transifex
 

--- a/include/config.mk
+++ b/include/config.mk
@@ -4,7 +4,7 @@
 # Edit these variables as appropriate.
 
 # The space-separated, period-prefixed translations to build (for easier substitutions).
-TRANSLATIONS=
+TRANSLATIONS=.es
 # The source language and translations to build.
 LANGUAGES=.en $(TRANSLATIONS)
 
@@ -30,7 +30,7 @@ TRANSIFEX_PROJECT=
 # Compile PO files for codelists and schema to MO files, so that `translate` succeeds.
 .PHONY: compile
 compile:
-	# pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)schema
-	# pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)codelists
+	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)schema
+	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)codelists
 
 # Put local targets below.

--- a/include/config.mk
+++ b/include/config.mk
@@ -25,13 +25,13 @@ DOMAIN_PREFIX=infrastructure
 # Directory containing assets to copy to the build directory (no trailing slash).
 ASSETS_DIR=
 # The Transifex project name.
-TRANSIFEX_PROJECT=
+TRANSIFEX_PROJECT=oc4ids-09
 
-# Compile PO files for codelists and schema to MO files, so that `translate` succeeds.
+# Compile PO files for codelists, schema and mappings to MO files, so that `translate` succeeds.
 .PHONY: compile
 compile:
 	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)schema
 	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)codelists
-	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)mapping
+	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)mappings
 
 # Put local targets below.

--- a/include/config.mk
+++ b/include/config.mk
@@ -32,5 +32,6 @@ TRANSIFEX_PROJECT=
 compile:
 	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)schema
 	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)codelists
+	 pybabel compile --use-fuzzy -d $(LOCALE_DIR) -D $(DOMAIN_PREFIX)mapping
 
 # Put local targets below.

--- a/locale/es/LC_MESSAGES/404.po
+++ b/locale/es/LC_MESSAGES/404.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Charlie Pinder <charlie.pinder@opendataservices.coop>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/404.md:5
+msgid "404 Not found"
+msgstr "404 Not Found"
+
+#: ../../docs/404.md:7
+msgid ""
+"We couldn't find the page you were looking for in this version of the "
+"documentation."
+msgstr ""
+"No pudimos encontrar la página que buscabas en esta versión de la "
+"documentación"
+
+#: ../../docs/404.md:9
+msgid ""
+"Try looking from the [home page](index), or use the search or navigation on "
+"the left hand side of the page."
+msgstr ""
+"Intente buscar desde la [página de inicio](index), o use la búsqueda o "
+"navegación en el lado izquierdo de la página."

--- a/locale/es/LC_MESSAGES/_static/docson/README.po
+++ b/locale/es/LC_MESSAGES/_static/docson/README.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2019\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/_static/docson/README.md:1
+msgid "Docson"
+msgstr "Docson"
+
+#: ../../docs/_static/docson/README.md:3
+msgid ""
+"Open Data Services fork of "
+"[lbovet/docson](https://github.com/lbovet/docson)."
+msgstr ""
+"Rama de Open Data Services de "
+"[lbovet/docson](https://github.com/lbovet/docson)."
+
+#: ../../docs/_static/docson/README.md:5
+msgid ""
+"This fork is used to customise Docson for a number of repositories using it "
+"and, in principle, it is not meant to contribute to the base repository."
+msgstr ""
+"Esta rama se utiliza para personalizar Docson en algunos repositorios que lo"
+" utilizan y, en principio, no está pensada como una contribución para el "
+"repositorio base."
+
+#: ../../docs/_static/docson/README.md:7
+msgid ""
+"For more information on using Docson, please refer to "
+"[lbovet/docson](https://github.com/lbovet/docson)."
+msgstr ""
+"Para más información sobre el uso de Docson, vea "
+"[lbovet/docson](https://github.com/lbovet/docson)."

--- a/locale/es/LC_MESSAGES/about.po
+++ b/locale/es/LC_MESSAGES/about.po
@@ -1,0 +1,235 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Charlie Pinder <charlie.pinder@opendataservices.coop>, 2019
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/about.md:1
+msgid "About"
+msgstr "Acerca de"
+
+#: ../../docs/about.md:4
+msgid ""
+"The [Open Contracting Partnership](http://www.open-contracting.org), "
+"[CoST](http://www.constructiontransparency.org/) - the Infrastructure "
+"Transparency Initiative - and [Open Data Services Co-"
+"operative](http://www.opendataservices.coop) are working together to "
+"document how the [Open Contracting Data Standard](https://standard.open-"
+"contracting.org), and additional standardized data models, can be used to "
+"represent, share and analyze all the information required under the [CoST "
+"Infrastructure Data Standard](http://infrastructuretransparency.org/wp-"
+"content/uploads/2018/06/36_List_of_CoST_Project_Information.pdf)."
+msgstr ""
+"La [Open Contracting Partnership](http://www.open-contracting.org), "
+"[CoST](http://www.constructiontransparency.org/) - la Iniciativa de "
+"Transparencia en Infraestructura - y [Open Data Services Co-"
+"operative](http://www.opendataservices.coop) están trabajando juntos para "
+"documentar cómo el [Estándar de Datos de Contrataciones "
+"Abiertas](https://standard.open-contracting.org/latest/es/), y modelos "
+"adicionales de datos estandarizados, pueden ser usados para representar, "
+"compartir y analizar toda la información requerida bajo el [Estándar de "
+"Datos sobre Infraestructura CoST](http://costhonduras.hn/wp-"
+"content/uploads/2020/05/estandar-de-datos-cost.pdf)."
+
+#: ../../docs/about.md:6
+msgid ""
+"You can get involved via the [issue tracker](https://github.com/open-"
+"contracting/infrastructure), or for more information about this work, "
+"contact [Bernadine Fernz](mailto:bfernz@open-contracting.org), Head of "
+"Infrastructure at the Open Contracting Partnership and/or [Evelyn "
+"Hernandez](mailto:e.hernandez@constructiontransparency.org), Head of Members"
+" and Affiliate Programmes at CoST."
+msgstr ""
+"Puede involucrarse mediante el [issue tracker](https://github.com/open-"
+"contracting/infrastructure), o para más información sobre este trabajo, "
+"contacte a [Bernadine Fernz](mailto:bfernz@open-contracting.org), Jefa de "
+"Infraestructura en la Open Contracting Partnership y/o a [Evelyn "
+"Hernández](mailto:e.hernandez@constructiontransparency.org), Jefa de "
+"Programas Miembros y Afiliados en CoST."
+
+#: ../../docs/about.md:8
+msgid ""
+"Read more about [Open Contracting and Infrastructure on the Open Contracting"
+" Partnership Blog](https://www.open-contracting.org/tag/infrastructure/)"
+msgstr ""
+"Lea más sobre [Contratos Abiertos e Infraestructura en el blog de Open "
+"Contracting Partnership](https://www.open-"
+"contracting.org/tag/infrastructure/)"
+
+#: ../../docs/about.md:10
+msgid "Background"
+msgstr "Antecedentes"
+
+#: ../../docs/about.md:12
+msgid ""
+"The Open Contracting Data Standard is already used to describe millions of "
+"procurement processes around the world relating to goods, services and "
+"public works."
+msgstr ""
+"El Estándar de Datos de Contrataciones Abiertas es usado actualmente para "
+"describir millones de procesos de contratación alrededor del mundo "
+"relacionados a bienes, servicios y obras públicas."
+
+#: ../../docs/about.md:14
+msgid ""
+"CoST, the Infrastructure Transparency Initiative, has identified [67 key "
+"items of information](http://infrastructuretransparency.org/wp-"
+"content/uploads/2018/06/36_List_of_CoST_Project_Information.pdf) that should"
+" be **pro-actively and reactively disclosed** for public works projects in "
+"order to support stakeholders to monitor these infrastructure projects, and "
+"to carry out assurance activities."
+msgstr ""
+"CoST, la Iniciativa de Transparencia en Infraestructura, ha identificado  "
+"[67 puntos clave de información](http://infrastructuretransparency.org/wp-"
+"content/uploads/2018/06/36_List_of_CoST_Project_Information.pdf) que "
+"deberían ser **divulgados proactiva y reactivamente** sobre los proyectos de"
+" obras públicas, con el fin de ayudar a las partes interesadas a monitorear "
+"estos proyectos de infraestructura, y a llevar a cabo procesos de "
+"aseguramiento."
+
+#: ../../docs/about.md:16
+msgid ""
+"These 67 elements cover both **project information** and **contract "
+"information** for the planning, preparation, procurement and implementation "
+"phases of an infrastructure project and its associated contracting "
+"processes."
+msgstr ""
+"Estos 67 puntos cubren tanto **información del proyecto** como **información"
+" de contratos** sobre las fases de planificación, preparación, adquisición e"
+" implementación de un proyecto de infraestructura y sus correspondientes "
+"procesos de contratación."
+
+#: ../../docs/about.md:18
+msgid ""
+"A lot of the information identified by CoST may be captured through "
+"contracting processes:"
+msgstr ""
+"Mucha de la información identificada por CoST puede ser capturada mediante "
+"de procesos de contratación:"
+
+#: ../../docs/about.md:20
+msgid "Contracts are issued for planning, design and preparation work;"
+msgstr ""
+"Se elaboran contratos para la planificación, diseño y trabajos preparativos;"
+
+#: ../../docs/about.md:21
+msgid "Contracts are issued for construction of infrastructure;"
+msgstr "Se elaboran contratos para la construcción de infraestructura;"
+
+#: ../../docs/about.md:22
+msgid "Contracts are issued for monitoring construction implementation."
+msgstr ""
+"Se elaboran contratos para monitorear o supervisar las construcciones."
+
+#: ../../docs/about.md:24
+msgid ""
+"When open contracting principles and practices are put in place, data about "
+"these contracting processes, and documents associated with them, should be "
+"openly available in standard formats."
+msgstr ""
+"Cuando se establecen prácticas y principios de contratos abiertos, los datos"
+" sobre estos procesos de contratación, y los documentos asociados a ellos, "
+"deberían estar disponibles públicamente en formatos estándar."
+
+#: ../../docs/about.md:26
+msgid ""
+"By linking existing open contracting disclosure (and ensuring key fields and"
+" documents are provided) with project-level information, new opportunities "
+"for data-driven infrastructure project monitoring are unlocked."
+msgstr ""
+"Enlazando la divulgación existente de contrataciones abiertas (y asegurando "
+"que campos y documentos clave son proveídos) con información a nivel de "
+"proyecto, se habilitan nuevas oportunidades para el monitoreo de proyectos "
+"de infraestructura basado en datos."
+
+#: ../../docs/about.md:28
+msgid "Theory of change and work plan"
+msgstr "Teoría de cambio y plan de trabajo"
+
+#: ../../docs/about.md:30
+msgid ""
+"This project, running from June 2018 through to March 2019, has the "
+"following theory of change."
+msgstr ""
+"Este proyecto, que se desarrolla desde Junio del 2018 hasta Marzo del 2019, "
+"tiene la siguiente teoría de cambio."
+
+#: ../../docs/about.md:32
+msgid ""
+"![Theory of Change](../_static/images/OC-CoST-TheoryOfChange-June2018.png)"
+msgstr ""
+"![Teoría de Cambio](../_static/images/es/OC-CoST-TheoryOfChange-"
+"June2018.png)"
+
+#: ../../docs/about.md:34
+msgid ""
+"The technical development work plan consists of the following four "
+"components:"
+msgstr ""
+"El plan de trabajo de desarrollo técnico consiste en los siguientes cuatro "
+"componentes:"
+
+#: ../../docs/about.md:36
+msgid ""
+"**Supply and demand research (June/July 2018)** - exploring the extent to "
+"which existing open contracting data can be used to understand major "
+"infrastructure projects and fulfill reporting requirements of the CoST "
+"Infrastructure Data Standard."
+msgstr ""
+"**Investigación de la oferta y demanda (Junio/Julio 2018)** - explorar hasta"
+" qué punto los datos abiertos de contrataciones existentes pueden ser usados"
+" para entender grandes proyectos de infraestructura y cumplir con los "
+"requerimientos de reporte del Estándar de Datos de Infraestructura CoST."
+
+#: ../../docs/about.md:38
+msgid ""
+"**Project identifier research (June/July 2018)** - identifying the "
+"opportunities to bring together data on projects through use of unique "
+"project identifiers."
+msgstr ""
+"**Investigación sobre identificadores de proyecto (Junio/Julio 2018)** - "
+"identificar las oportunidades de unir datos de proyectos mediante el uso de "
+"identificadores únicos de proyecto."
+
+#: ../../docs/about.md:40
+msgid ""
+"**Schema and guidance development (July - September 2018)** - providing a "
+"clearly documented approach to the use of the core Open Contracting Data "
+"Standard (and extensions if appropriate) to provide the proactive "
+"disclosures required by CoST, and outlining implementation models for this."
+msgstr ""
+"**Desarrollo del esquema y guía (Julio - Setiembre 2018)** - proveer una "
+"propuesta claramente documentada sobre el uso del Estándar de Datos de "
+"Contrataciones Abiertas básico (y extensiones si es apropiado) para proveer "
+"las divulgaciones proactivas requeridas por CoST, y delinear modelos de "
+"implementación para ello."
+
+#: ../../docs/about.md:42
+msgid ""
+"**Implementation resources (October 2018 - February 2019)** - creating "
+"guidance for implementers seeking to deploy the open contracting data "
+"standard for infrastructure projects"
+msgstr ""
+"**Recursos de implementación (Octubre 2018 - Febrero 2019)** - crear una "
+"guía para implementadores que busquen desplegar  las Contrataciones Abiertas"
+" para Estándar de Datos sobre Infraestructura."

--- a/locale/es/LC_MESSAGES/cost/index.po
+++ b/locale/es/LC_MESSAGES/cost/index.po
@@ -1,0 +1,315 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/cost/index.md:6
+msgid "CoST IDS & OCDS Mapping"
+msgstr "CoST IDS & Mapeo OCDS"
+
+#: ../../docs/cost/index.md:8
+msgid ""
+"CoST – the Infrastructure Transparency Initiative (CoST) is the leading "
+"global initiative improving transparency and accountability in public "
+"infrastructure."
+msgstr ""
+"CoST – la Iniciativa para la Transparencia en Infraestructura (CoST) es la "
+"iniciativa global líder que mejora la transparencia y la rendición de "
+"cuentas en infraestructura pública."
+
+#: ../../docs/cost/index.md:10
+msgid ""
+"The [CoST approach](http://infrastructuretransparency.org/our-approach/) is "
+"based on four core features:"
+msgstr ""
+"El [enfoque de CoST](http://infrastructuretransparency.org/our-approach/) se"
+" basa en cuatro características clave:"
+
+#: ../../docs/cost/index.md:12
+msgid ""
+"**Disclosure** - where procuring entities are asked to follow the CoST "
+"Infrastructure Data Standard. This describes 40 items of data that should be"
+" proactively disclosed at key stages of an infrastructure project cycle."
+msgstr ""
+"**Divulgación** - donde se solicita a las entidades de adquisición que sigan"
+" el Estándar de Datos sobre Infraestructura de CoST. Este describe 40 "
+"elementos de datos que deberían ser divulgados proactivamente en etapas "
+"clave del ciclo de un proyecto de infraestructura. "
+
+#: ../../docs/cost/index.md:14
+msgid ""
+"**Assurance** -  an independent review of the disclosed data by assurance "
+"teams based within CoST national programmes. Teams may identify key issues "
+"of concern analyzing the data that has been disclosed, and will put "
+"technical terms into plain language to allow stakeholders to understand the "
+"issues, and hold decision makers to account."
+msgstr ""
+"**Aseguramiento** - es una revisión independiente de los datos divulgados "
+"por parte de equipos de aseguramiento establecidos en el marco de los "
+"programas nacionales de CoST. Los equipos pueden identificar motivos de "
+"preocupación clave analizando los datos que han sido divulgados, y "
+"convertirán términos técnicos en lenguaje sencillo para que las partes "
+"interesadas entiendan los problemas, y soliciten rendición de cuentas a los "
+"tomadores de decisiones."
+
+#: ../../docs/cost/index.md:16
+msgid ""
+"**Multi-stakeholder working** - each CoST national programme is managed by a"
+" stakeholder group including government, private sector and civil society."
+msgstr ""
+"**Trabajo multisectorial** - cada programa nacional o sub-nacional de CoST "
+"es administrado por un grupo multisectorial que incluye el gobierno, el "
+"sector privado y la sociedad civil."
+
+#: ../../docs/cost/index.md:18
+msgid ""
+"**Social accountability** - raising awareness of key issues arising from the"
+" assurance process, and engaging civil society and media to hold decision "
+"makers to account."
+msgstr ""
+"**Auditoría social** - concienciando sobre preocupaciones clave que surgen "
+"del proceso de aseguramiento, e involucrando a la sociedad civil y a los "
+"medios para que demanden rendición de cuentas a los encargados de los "
+"proyectos."
+
+#: ../../docs/cost/index.md:20
+msgid ""
+"The 'Infrastructure Data Standard' is a **framework for disclosure** which "
+"has been adapted by a range of CoST national programmes, who have variously "
+"prioritized different elements based on their local needs, or who have "
+"included additional elements that they wish to monitor: particularly "
+"additional kinds of documentation that should be provided for each "
+"infrastructure project."
+msgstr ""
+"El 'Estándar de Datos sobre Infraestructura' es un **marco de trabajo para "
+"divulgación** que ha sido adaptado por un rango de programas de CoST, "
+"quienes han priorizado de manera distinta diferentes elementos en base a sus"
+" necesidades locales, o quienes han incluido elementos adicionales que "
+"desean monitorear: particularmente, tipos de documentación adicionales que "
+"deberían ser proveídos por cada proyecto de infraestructura."
+
+#: ../../docs/cost/index.md:22
+msgid ""
+"You can read more about the Infrastructure Data Standard in [CoST Guidance "
+"Note 6](http://infrastructuretransparency.org/resource/guidance-"
+"note-6-designing-a-disclosure-process/)."
+msgstr ""
+"Puede leer más sobre el Estándar de Datos sobre Infraestructura en la [Nota "
+"de Orientación 6 de CoST](http://infrastructuretransparency.org/resource"
+"/guidance-note-6-designing-a-disclosure-process/)."
+
+#: ../../docs/cost/index.md:1
+msgid "Frameworks and standards"
+msgstr "Marcos y estándares"
+
+#: ../../None:1
+msgid ""
+"There is an important distinction between the Infrastructure Data Standard "
+"(IDS) and the Open Contracting Data Standard (OCDS). IDS provides a "
+"framework to identify *categories of information* that should be disclosed. "
+"OCDS describes *specific fields* and how they should be structured as data."
+msgstr ""
+"Hay una distinción importante entre el Estándar de Datos sobre "
+"Infraestructura (IDS) y el Estándar de Datos de Contrataciones Abiertas "
+"(OCDS). IDS provee un marco para identificar *categorías de información* que"
+" deberían ser publicadas. OCDS describe *campos específicos* y cómo deberían"
+" estar estructurados como datos."
+
+#: ../../None:3
+msgid ""
+"The [Open Contracting for Infrastructure Data Standard "
+"(OC4IDS)](../projects/index) documented on this site acts as a bridge "
+"between the IDS framework, and the idea of a more structured technical data "
+"standard."
+msgstr ""
+"Las [ Contrataciones Abiertas para el Estándar de Datos sobre "
+"Infraestructura (OC4IDS, por sus siglas en inglés)](../projects/index) "
+"documentadas en este sitio actúan como un puente entre el marco de trabajo "
+"IDS, y la idea de un estándar de datos técnico más estructurado."
+
+#: ../../docs/cost/index.md:36
+msgid "Mapping to IDS and from OCDS"
+msgstr "Mapeo a IDS y desde OCDS"
+
+#: ../../docs/cost/index.md:40
+msgid "The following mapping tables describe:"
+msgstr "Las siguientes tablas de mapeo describen:"
+
+#: ../../docs/cost/index.md:42
+msgid ""
+"How each element of the CoST Infrastructure Data Standard can be represented"
+" as **structured data** using the [Open Contracting for Infrastructure Data "
+"Standard](../projects/index), in the 'Mapping to OC4IDS' column."
+msgstr ""
+"Cómo cada elemento del Estándar de Datos sobre Infraestructura CoST puede "
+"ser representado como **datos estructurados** usando las [Contrataciones "
+"Abiertas para el Estándar de Datos sobre "
+"Infraestructura](../projects/index), en la columna 'Mapeo a OC4IDS'."
+
+#: ../../docs/cost/index.md:44
+msgid ""
+"How existing OCDS data can be used to populate project-level and contracting"
+" process summary data, in the 'Mapping from OCDS' column."
+msgstr ""
+"Cómo los datos OCDS existentes pueden ser usados para llenar datos a nivel "
+"de proyecto y de resumen de procesos de contratación, en la columna 'Mapeo "
+"desde OCDS'."
+
+#: ../../docs/cost/index.md:1
+msgid "Mapping from OCDS"
+msgstr "Mapeo desde OCDS"
+
+#: ../../None:1
+msgid ""
+"Some mappings use fields from [OCDS extensions](https://standard.open-"
+"contracting.org/1.1/en/extensions/). In these cases, the names of extensions"
+" are noted in parentheses; where possible, alternative mappings are provided"
+" that use only fields from the core OCDS schema."
+msgstr ""
+"Algunos mapeos usan campos de [extensiones OCDS](https://standard.open-"
+"contracting.org/1.1/es/extensions/). En estos casos, los nombres de las "
+"extensiones se muestran entre paréntesis; cuando es posible, se proveen "
+"mapeos alternativos que sólo usan campos del esquema OCDS principal."
+
+#: ../../docs/cost/index.md:56
+msgid "Project level"
+msgstr "Nivel de proyecto"
+
+#: ../../docs/cost/index.md:58
+msgid "Project identification"
+msgstr "Identificación del proyecto"
+
+#: ../../docs/cost/index.md:67
+msgid "Project preparation"
+msgstr "Preparación del proyecto"
+
+#: ../../docs/cost/index.md:76
+msgid "Project completion"
+msgstr "Finalización del proyecto"
+
+#: ../../docs/cost/index.md:85
+msgid "Process level"
+msgstr "Nivel de proceso"
+
+#: ../../docs/cost/index.md:87
+msgid "Procurement"
+msgstr "Adquisiciones"
+
+#: ../../docs/cost/index.md:96
+msgid "Implementation"
+msgstr "Implementación"
+
+#: ../../docs/cost/index.md:98
+msgid ""
+"Disclosures in the implementation section of the CoST IDS relate to changes "
+"to a contract's value, duration or scope that were made after the contract "
+"was awarded."
+msgstr ""
+"La divulgación en la sección de implementación en el IDS de CoST se "
+"relacionan a cambios en el valor, duración o alcance del contrato que fueron"
+" hechos después de que el contrato fue adjudicado."
+
+#: ../../docs/cost/index.md:100
+msgid ""
+"If OCDS data is available, these changes can be determined by comparing the "
+"most recent OCDS release to a compiled release created from all prior "
+"releases (to better understand these concepts, refer to the [OCDS "
+"documentation](https://standard.open-"
+"contracting.org/1.1/en/getting_started/releases_and_records/)). The specific"
+" fields to monitor for changes between releases are described in the mapping"
+" table below."
+msgstr ""
+"Si hay datos OCDS disponibles, estos cambios se pueden determinar comparando"
+" el release OCDS más reciente con un release compilado creado a partir de "
+"todos los releases anteriores (para entender mejor estos conceptos, vea la "
+"[documentación de OCDS](https://standard.open-"
+"contracting.org/1.1/es/getting_started/releases_and_records/)). El campo "
+"específico a observar para cambios entre releases se describen en la tabla "
+"de mapeo de abajo."
+
+#: ../../docs/cost/index.md:102
+msgid ""
+"In some cases, OCDS data may include an explanation of changes in the "
+"relevant `amendments` block. In other cases, the reason may need to be "
+"manually entered."
+msgstr ""
+"En algunos casos, los datos OCDS pueden incluir una explicación de los "
+"cambios en el bloque `amendments` correspondiente. En otros casos, la razón "
+"puede necesitar ser ingresada manualmente."
+
+#: ../../docs/cost/index.md:111
+msgid "Reactive disclosures"
+msgstr "Divulgación reactiva"
+
+#: ../../docs/cost/index.md:113
+msgid ""
+"The CoST IDS also sets out a number of data points under the heading of "
+"'reactive disclosure'. It is possible to also disclose many of these fields "
+"**pro-actively** either as **document** entries with free text or linked "
+"documents, or using structured OCDS fields and extensions."
+msgstr ""
+"El IDS de CoST establece un número de datos específicos bajo el título de "
+"'divulgación reactiva'. También es posible publicar varios de estos de "
+"campos de forma **proactiva** ya sea como entradas de **documentos** con "
+"texto libre o documentos enlazados, o usando campos OCDS estructurados y "
+"extensiones."
+
+#: ../../docs/cost/index.md:115
+msgid "Specifically:"
+msgstr "Específicamente:"
+
+#: ../../docs/cost/index.md:117
+msgid ""
+"Details of a individuals involved at the project or contract level can be "
+"included in the ``parties`` array with a suitable role. Role is an open "
+"codelist. As individuals will not have an 'organization identifier' a "
+"locally defined identifier may be used instead."
+msgstr ""
+"Los detalles de los individuos involucrados a nivel de proyecto o contrato "
+"pueden ser incluidos en la lista de ``parties`` con un rol apropiado. Rol es"
+" una lista de códigos abierta. Ya que los individuos no poseen un "
+"'identificador de organización' un identificador definido localmente puede "
+"ser usado en su lugar."
+
+#: ../../docs/cost/index.md:119
+msgid ""
+"Plans, reports and assessments may be included in the project or contracting"
+" process level `documents` blocks, or may be published within individual "
+"OCDS releases."
+msgstr ""
+"Planes, reportes y evaluaciones pueden ser incluidos en los bloques "
+"`documents` al nivel de proyecto o de proceso de contratación, o pueden ser "
+"publicados dentro de \"releases\" OCDS individuales."
+
+#: ../../docs/cost/index.md:121
+msgid ""
+"The [budget_breakdown](https://github.com/open-contracting-"
+"extensions/ocds_budget_breakdown_extension) and "
+"[budget_and_spend](https://github.com/open-contracting-"
+"extensions/ocds_budget_and_spend_extension) extensions can be used to "
+"provide guidance on modelling detailed financial information."
+msgstr ""
+"Las extensiones [budget_breakdown](https://github.com/open-contracting-"
+"extensions/ocds_budget_breakdown_extension) y "
+"[budget_and_spend](https://github.com/open-contracting-"
+"extensions/ocds_budget_and_spend_extension) pueden ser usadas para proveer "
+"orientación sobre el modelado de información financiera detallada."

--- a/locale/es/LC_MESSAGES/guidance/data_user_guide.po
+++ b/locale/es/LC_MESSAGES/guidance/data_user_guide.po
@@ -1,0 +1,93 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2020-05-13 23:48+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/data_user_guide.md:1
+msgid "Data user guide"
+msgstr "Guía para el usuario de datos"
+
+#: ../../docs/guidance/data_user_guide.md:3
+msgid ""
+"Publishing OC4IDS involves making choices about what projects, data and "
+"documents to include and/or exclude, and how to map existing data elements "
+"to the fields in OC4IDS."
+msgstr ""
+"Publicar en OC4IDS involucra elegir qué proyectos, datos y documentos se "
+"incluyen o excluyen, y cómo mapear elementos de datos existentes a los "
+"campos en OC4IDS."
+
+#: ../../docs/guidance/data_user_guide.md:5
+msgid ""
+"In order for users to interpret data correctly and make effective use of it,"
+" it's important for publishers to describe these local decisions and to "
+"provide guidance to data users that includes:"
+msgstr ""
+"Para que los usuarios puedan interpretar los datos correctamente y hacer un "
+"uso efectivo de ellos, es importante que los publicadores describan estas "
+"decisiones locales y que provean orientación a los usuarios de datos que "
+"incluya:"
+
+#: ../../docs/guidance/data_user_guide.md:7
+msgid "the purpose of publication"
+msgstr "el propósito de la publicación"
+
+#: ../../docs/guidance/data_user_guide.md:8
+msgid "how the data is generated"
+msgstr "cómo los datos son generados"
+
+#: ../../docs/guidance/data_user_guide.md:9
+msgid "the data's scope and format"
+msgstr "el alcance y formato de los datos"
+
+#: ../../docs/guidance/data_user_guide.md:10
+msgid "how the data can be reused"
+msgstr "cómo los datos pueden ser reusados"
+
+#: ../../docs/guidance/data_user_guide.md:11
+msgid "how the publisher can be contacted"
+msgstr "cómo se puede contactar con el publicador"
+
+#: ../../docs/guidance/data_user_guide.md:13
+msgid ""
+"Publishers should link to this data user guide from the project package's "
+"`publicationPolicy` field."
+msgstr ""
+"Los publicadores deberían incluir un enlace a esta guía de usuarios de datos"
+" en el campo `publicationPolicy` del paquete de proyectos."
+
+#: ../../docs/guidance/data_user_guide.md:15
+msgid ""
+"For more information, please refer to the [OCDS publication policy "
+"guidance](https://standard.open-"
+"contracting.org/1.1/en/implementation/publication_policy/). For assistance "
+"in drafting a data user guide, please refer to the [OCDS publication policy "
+"template](https://www.open-contracting.org/resources/ocds-1-1-publication-"
+"policy-template/)."
+msgstr ""
+"Para más información, favor consulte la [guía de políticas de publicación de"
+" OCDS](https://standard.open-"
+"contracting.org/1.1/es/implementation/publication_policy/). Para asistencia "
+"en redactar una guía para el usuario de datos, favor consulte la [plantilla "
+"de política de publicación OCDS](https://www.open-"
+"contracting.org/resources/ocds-1-1-plantilla-de-politica-de-publicacion-"
+"es/)."

--- a/locale/es/LC_MESSAGES/guidance/evaluating.po
+++ b/locale/es/LC_MESSAGES/guidance/evaluating.po
@@ -1,0 +1,215 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/evaluating.md:1
+msgid "Assessing compliance with the CoST IDS"
+msgstr "Evaluación de conformidad con el IDS de CoST"
+
+#: ../../docs/guidance/evaluating.md:3
+msgid ""
+"The CoST Infrastructure Data Standard (IDS) is a framework for disclosure "
+"which is adapted by CoST national programmes to meet their local needs. This"
+" section sets out how to use **OC4IDS** and **OCDS** to assess coverage of "
+"published data against the IDS. For example, to monitor which elements of "
+"IDS are being supplied and whether they are available for all projects or "
+"only some."
+msgstr ""
+"El Estándar de Datos sobre Infraestructura de CoST (IDS) es un marco para "
+"publicaciones que fue adaptado por programas nacionales CoST para satisfacer"
+" sus necesidades locales. Esta sección establece cómo usar **OC4IDS** y "
+"**OCDS** para evaluar la cobertura de los datos publicados de acuerdo al "
+"IDS. Por ejemplo, para monitorear qué elementos del IDS están siendo "
+"proveídos y si están disponibles para todos los proyectos o sólo para "
+"algunos."
+
+#: ../../docs/guidance/evaluating.md:1
+msgid "Note"
+msgstr "Nota"
+
+#: ../../None:1
+msgid ""
+"It is not possible to fully automate checks of whether disclosures from a "
+"particular publisher, or disclosures about a particular project, meet the "
+"requirements of the CoST IDS. For example, a human check may be needed to "
+"determine whether documents linked to from the data contain the required "
+"information."
+msgstr ""
+"No es posible automatizar completamente las verificaciones sobre si las "
+"publicaciones de un publicador en particular, o de un proyecto en "
+"particular, cumplen los requerimientos del IDS de CoST. Por ejemplo, se "
+"puede necesitar una verificación manual para determinar si los documentos "
+"enlazados a los datos contienen la información requerida."
+
+#: ../../docs/guidance/evaluating.md:15
+msgid "Getting started"
+msgstr "Para empezar"
+
+#: ../../docs/guidance/evaluating.md:17
+msgid ""
+"*The following steps may require support from a technical expert. You can "
+"also contact the OC4IDS Helpdesk ([data@open-contracting.org](mailto:data"
+"@open-contracting.org)) for guidance.*"
+msgstr ""
+"*Los siguientes pasos pueden requerir la ayuda de un experto técnico. Usted "
+"también puede contactar con el Helpdesk de OC4IDS ([data@open-"
+"contracting.org](mailto:data@open-contracting.org)) para orientación.*"
+
+#: ../../docs/guidance/evaluating.md:19
+msgid "(1) Check your data formats"
+msgstr "(1) Verifique el formato de sus datos"
+
+#: ../../docs/guidance/evaluating.md:21
+msgid ""
+"First, check that the disclosures you want to analyze are in the correct "
+"format. If they are not in the correct format, you will need to convert the "
+"data."
+msgstr ""
+"Primero, verifique que las publicaciones que quiere analizar estén en el "
+"formato correcto. Si no están en el formato correcto, necesitará convertir "
+"los datos."
+
+#: ../../docs/guidance/evaluating.md:23
+msgid "Project level data"
+msgstr "Datos a nivel de proyecto"
+
+#: ../../docs/guidance/evaluating.md:25
+msgid ""
+"Check whether the project-level data is published using "
+"[OC4IDS](../../projects/index)"
+msgstr ""
+"Verifique si los datos a nivel de proyecto son publicados usando "
+"[OC4IDS](../../projects/index)"
+
+#: ../../docs/guidance/evaluating.md:1 ../../docs/guidance/evaluating.md:1
+#: ../../docs/guidance/evaluating.md:1
+msgid "Tip"
+msgstr "Consejo"
+
+#: ../../None:1
+msgid ""
+"You can use the [OC4IDS Data Review Tool](https://standard.open-"
+"contracting.org/infrastructure/review/) to check that whether your data is "
+"in the correct format."
+msgstr ""
+"Puede usar la [Herramienta de revisión de datos OC4IDS](https://standard"
+".open-contracting.org/infrastructure/review/) para verificar si sus datos "
+"están en el formato correcto."
+
+#: ../../docs/guidance/evaluating.md:37
+msgid ""
+"If the data isn’t published using OC4IDS, use the [OC4IDS Field-Level "
+"Mapping Template](https://www.open-contracting.org/resources/oc4ids-field-"
+"level-mapping-template/) to map the data to the specification and create an "
+"OC4IDS JSON file for each project."
+msgstr ""
+"Si los datos no están publicados usando OC4IDS, use la [Plantilla de Mapeo a"
+" Nivel de Campos OC4IDS](https://www.open-contracting.org/resources/oc4ids-"
+"field-level-mapping-template/) para mapear los datos a la especificación y "
+"crear un archivo JSON OC4IDS para cada proyecto."
+
+#: ../../None:1
+msgid ""
+"You can use a [blank example OC4IDS JSON file](../../_static/blank.json) to "
+"get started."
+msgstr ""
+"Puede usar un [archivo de ejemplo OC4IDS JSON en "
+"blanco](../../_static/blank.json) para empezar."
+
+#: ../../docs/guidance/evaluating.md:49
+msgid "Contracting data"
+msgstr "Datos de contrataciones"
+
+#: ../../docs/guidance/evaluating.md:51
+msgid "Check whether the contracting data is published using OCDS."
+msgstr "Verifique si los datos de contratación son publicados usando OCDS."
+
+#: ../../None:1
+msgid ""
+"You can use the [OCDS Data Review Tool](https://standard.open-"
+"contracting.org/review/) to check that whether your data is published in "
+"OCDS format."
+msgstr ""
+"Puede usar la [Herramienta de revisión de datos OCDS](https://standard.open-"
+"contracting.org/review/) para verificar si sus datos están publicados en "
+"formato OCDS."
+
+#: ../../docs/guidance/evaluating.md:63
+msgid ""
+"If the contracting data is published using OCDS then use it to populate the "
+"contracting processes section of the project-level data, following the "
+"guidance on [using contracting data to understand infrastructure "
+"projects](using)."
+msgstr ""
+"Si los datos de contratación están publicados en OCDS úselos para llenar la "
+"sección de procesos de contratación de los datos a nivel de proyecto, "
+"siguiendo la guía sobre [usar datos de contratación para entender los "
+"proyectos de infraestructura](using)."
+
+#: ../../docs/guidance/evaluating.md:65
+msgid ""
+"If the data isn’t published using OCDS, use the [OC4IDS Field-Level Mapping "
+"Template](https://www.open-contracting.org/resources/oc4ids-field-level-"
+"mapping-template/) to map the data to the [contracting "
+"processes](../../reference/schema/#contractingprocess) section of OC4IDS and"
+" add the data to the OC4IDS JSON file for each project."
+msgstr ""
+"Si los datos no son publicados usando OCDS, use la [plantilla de mapeo a "
+"nivel de campos OC4IDS](https://www.open-contracting.org/resources/oc4ids-"
+"field-level-mapping-template/) para mapear los datos a la sección de "
+"[procesos de contratación](../../reference/schema/#contractingprocess) de "
+"OC4IDS y agregue los datos al archivo OC4IDS JSON para cada proyecto."
+
+#: ../../docs/guidance/evaluating.md:67
+msgid "(2) Check which elements of IDS are disclosed"
+msgstr "(2) Verifique qué elementos del IDS son publicados"
+
+#: ../../docs/guidance/evaluating.md:69
+msgid ""
+"Use the [CoST IDS Mapping](../../cost/index) to construct queries to "
+"determine which elements of the IDS are provided in the data."
+msgstr ""
+"Use el [Mapeo de CoST IDS](../../cost/index) para preparar consultas y "
+"determinar qué elementos del IDS se proveen en los datos."
+
+#: ../../docs/guidance/evaluating.md:71
+msgid ""
+"For example, the CoST IDS mapping describes how the project name element of "
+"the IDS should be disclosed:"
+msgstr ""
+"Por ejemplo, el mapeo del IDS de CoST describe cómo el elemento de nombre "
+"del proyecto de IDS debería ser publicado:"
+
+#: ../../docs/guidance/evaluating.md:73
+msgid "Project-Level: Publish as `title`"
+msgstr "Nivel de Proyecto: Publicar como `title`"
+
+#: ../../docs/guidance/evaluating.md:75
+msgid ""
+"Based on this description, the following pseudo code checks a folder "
+"containing OC4IDS JSON files to count the number of  projects in which the "
+"project name is disclosed:"
+msgstr ""
+"Basado en esta descripción, el siguiente pseudo código verifica una carpeta "
+"que contiene archivos JSON OC4IDS para contar el número de proyectos en los "
+"cuales se publica el nombre del proyecto:"

--- a/locale/es/LC_MESSAGES/guidance/example.po
+++ b/locale/es/LC_MESSAGES/guidance/example.po
@@ -1,0 +1,453 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/example.md:1
+msgid "Worked example"
+msgstr "Ejemplo práctico"
+
+#: ../../docs/guidance/example.md:3
+msgid ""
+"The [OC4IDS schema](../../reference/index) sets out the structure and format"
+" of an OC4IDS JSON file."
+msgstr ""
+"El [esquema OC4IDS](../../reference/index) establece la estructura y formato"
+" de un archivo OC4IDS JSON."
+
+#: ../../docs/guidance/example.md:5
+msgid ""
+"This worked example is a fully completed OC4IDS JSON file representing a "
+"fictional, completed infrastructure project to upgrade a motorway in the UK."
+msgstr ""
+"Este ejemplo práctico es un archivo JSON OC4IDS completo que representa un "
+"proyecto de infraestructura completo y ficticio para la reforma de una "
+"autopista en el Reino Unido."
+
+#: ../../docs/guidance/example.md:7
+msgid ""
+"The full OC4IDS JSON file for the worked example is available to download "
+"[here](../../_static/example.json)."
+msgstr ""
+"El archivo OC4IDS JSON completo para el ejemplo práctico está disponible "
+"para su descarga [aquí](../../_static/example.json)."
+
+#: ../../docs/guidance/example.md:9
+msgid ""
+"This page contains excerpts from the example JSON file, showing how key "
+"sections of the schema ought to be populated."
+msgstr ""
+"Esta página contiene extractos del archivo de ejemplo JSON, mostrando cómo "
+"deberían ser llenadas las secciones clave del esquema."
+
+#: ../../docs/guidance/example.md:11
+msgid "Overview"
+msgstr "Resumen"
+
+#: ../../docs/guidance/example.md:13
+msgid "An OC4IDS document is made up of a number of sections. These include:"
+msgstr ""
+"Un documento OC4IDS está hecho de un número de secciones. Estos incluyen:"
+
+#: ../../docs/guidance/example.md:15
+msgid ""
+"**Project package** - a container for the data of multiple projects, as well"
+" as metadata about the publication."
+msgstr ""
+"**Paquete de proyectos** - un contenedor para los datos de múltiples "
+"proyectos, así como metadatos sobre la publicación."
+
+#: ../../docs/guidance/example.md:16
+msgid "**Project data** - for each project including:"
+msgstr "**Datos de proyecto** - para cada proyecto incluyendo:"
+
+#: ../../docs/guidance/example.md:17
+msgid ""
+"**Project metadata** - contextual information about the project such as "
+"title, description, location and status."
+msgstr ""
+"**Metadatos de proyecto** - información contextual acerca del proyecto como "
+"el título, descripción, ubicación y estado."
+
+#: ../../docs/guidance/example.md:18
+msgid ""
+"**Budget** - information about the projected costs or allocated budget for "
+"the project."
+msgstr ""
+"**Presupuesto** - información sobre los costos previstos o presupuesto "
+"asignado para el proyecto."
+
+#: ../../docs/guidance/example.md:19
+msgid ""
+"**Parties** - information about the organizations and other participants "
+"involved in the project."
+msgstr ""
+"**Partes** - información sobre las organizaciones y otros participantes "
+"involucrados en el proyecto."
+
+#: ../../docs/guidance/example.md:20
+msgid "**Documents** - documents and documentation relating to the project."
+msgstr ""
+"**Documentos** - documentos y documentación relacionada con el proyecto."
+
+#: ../../docs/guidance/example.md:21
+msgid ""
+"**Contracting processes** - information about related contracting processes "
+"for different aspects of the project."
+msgstr ""
+"**Procesos de contratación** - información sobre los procesos de "
+"contratación relacionados para diferentes aspectos del proyecto."
+
+#: ../../docs/guidance/example.md:22
+msgid ""
+"**Completion** - information on the final scope, duration and costs for the "
+"project."
+msgstr ""
+"**Finalización** - información del alcance, duración y costos finales para "
+"el proyecto."
+
+#: ../../docs/guidance/example.md:24
+msgid "Sections"
+msgstr "Secciones"
+
+#: ../../docs/guidance/example.md:26
+msgid "Project package"
+msgstr "Paquete de proyectos"
+
+#: ../../docs/guidance/example.md:28
+msgid ""
+"The project package serves as a container for the data of multiple projects,"
+" through its `projects` array. It also provides metadata concerning all the "
+"data it contains, including the publisher, schema version, data license and "
+"publication policy."
+msgstr ""
+"El paquete de proyectos sirve como un contenedor para los datos de múltiples"
+" proyectos, a través de su array `projects`. También provee metadatos sobre "
+"todos los datos que contiene, incluyendo el publicador, versión del esquema,"
+" licencia de datos y política de publicación."
+
+#: ../../docs/guidance/example.md:38
+msgid "License"
+msgstr "Licencia"
+
+#: ../../docs/guidance/example.md:40
+msgid ""
+"The `license` field ought to contain a link to the license that applies to "
+"the data in the package. Further information about licensing can be found in"
+" the [OCDS licensing guidance](https://standard.open-"
+"contracting.org/1.1/en/implementation/licensing/)."
+msgstr ""
+"El campo `license` debería contener un enlace a la licencia que aplica a los"
+" datos en el paquete. Más información sobre licencias puede encontrarse en "
+"la [orientación de licencias de OCDS](https://standard.open-"
+"contracting.org/1.1/es/implementation/licensing/)."
+
+#: ../../docs/guidance/example.md:42
+msgid "Publication policy"
+msgstr "Política de publicación"
+
+#: ../../docs/guidance/example.md:44
+msgid ""
+"The `publicationPolicy` field ought to contain a link to a data user guide. "
+"For more information about what to include in a publication policy, refer to"
+" [Data user guide](data_user_guide)."
+msgstr ""
+"El campo `publicationPolicy` debería contener un enlace a una guía para "
+"usuarios de datos. Para más información sobre qué incluir en una política de"
+" publicación, consultar la [guía de usuarios de datos](data_user_guide)."
+
+#: ../../docs/guidance/example.md:46
+msgid "Project information"
+msgstr "Información de proyecto"
+
+#: ../../docs/guidance/example.md:48
+msgid ""
+"A project package can contain information about multiple infrastructure "
+"projects. Each infrastructure project is represented as an entry in the "
+"`projects` array. The example contains information about one infrastructure "
+"project."
+msgstr ""
+"Un paquete de proyecto puede contener información sobre múltiples proyectos "
+"de infraestructura. Cada proyecto de infraestructura es representado como "
+"una entrada en el array de `projects`. El ejemplo contiene información sobre"
+" un solo proyecto de infraestructura."
+
+#: ../../docs/guidance/example.md:60
+msgid "Each project object contains the following sections:"
+msgstr "Cada objeto de proyecto contiene las siguientes secciones:"
+
+#: ../../docs/guidance/example.md:62
+msgid "Project metadata"
+msgstr "Metadatos del proyecto"
+
+#: ../../docs/guidance/example.md:64
+msgid ""
+"This section provides contextual information about the infrastructure "
+"project, including:"
+msgstr ""
+"Esta sección provee información contextual sobre el proyecto de "
+"infraestructura, incluyendo:"
+
+#: ../../docs/guidance/example.md:66
+msgid ""
+"`id` for the project identifier. To make the project identifier globally "
+"unique, a project identifier prefix needs to be added to a local identifier "
+"for the project. Project identifier prefixes are assigned by the OC4IDS "
+"Helpdesk. For more information on project identifiers, refer to the [project"
+" identifiers guidance](../identifiers/#globally-unique-project-identifiers)."
+msgstr ""
+"`id` para el identificador de proyecto. Para hacer que el identificador de "
+"proyecto sea globalmente único, se necesita añadir un prefijo de "
+"identificador de proyecto a un identificador local para el proyecto. Los "
+"prefijos de identificador de proyecto son asignados por el Helpdesk de "
+"OC4IDS. Para más información sobre los identificadores de proyecto, consulte"
+" la [guía de identificadores de proyecto](../identifiers/#globally-unique-"
+"project-identifiers)."
+
+#: ../../docs/guidance/example.md:68
+msgid ""
+"`status` from the [Project Status "
+"codelist](../../reference/codelists/#projectstatus). In this example, the "
+"project status is 'completed'."
+msgstr ""
+"`status` (estatus) de la [lista de códigos de Estado de "
+"Proyecto](../../reference/codelists/#projectstatus). En este ejemplo, el "
+"estado del proyecto es 'completed' (finalizado)."
+
+#: ../../docs/guidance/example.md:70
+msgid ""
+"`type` from the [Project Type "
+"codelist](../../reference/codelists/#projecttype). In this example, the "
+"project type is 'expansion'."
+msgstr ""
+"`type` (tipo) de la [lista de códigos de Tipo de "
+"Proyecto](../../reference/codelists/#projecttype). En este ejemplo, el tipo "
+"de proyecto es 'expansion' (expansión)."
+
+#: ../../docs/guidance/example.md:72
+msgid ""
+"`sector` from the [Project Sector "
+"codelist](../../reference/codelists/#projectsector). In this example, the "
+"sector is 'transport.road', the parent sector 'transport' is also included "
+"in the sector list, in line with the guidance in the schema."
+msgstr ""
+"`sector` de la [lista de códigos de Sector de "
+"Proyecto](../../reference/codelists/#projectsector). En este ejemplo, el "
+"sector es `transport.road`, el sector padre `transport` también está "
+"incluido en la lista de sectores, tal como lo indica la guía en el esquema."
+
+#: ../../docs/guidance/example.md:74
+msgid ""
+"one or more `relatedProjects`, to reference other projects that are related "
+"to the same set of infrastructure assets, as [outlined in the schema "
+"reference](../../reference/schema/#relatedproject). In the relatedProject "
+"example below, a reference is made to the original project that initially "
+"constructed the motorway junctions, which are now being upgraded by this "
+"project."
+msgstr ""
+"uno o más `relatedProjects` (proyectos relacionados), para referenciar otros"
+" proyectos que están relacionados al mismo conjunto de activos de "
+"infraestructura, como está [resumido en la referencia del "
+"esquema](../../reference/schema/#relatedproject). En el ejemplo de "
+"relatedProject abajo, se hace referencia al proyecto original que construyó "
+"inicialmente el cruce de autopistas, que ahora está siendo mejorado por este"
+" proyecto."
+
+#: ../../docs/guidance/example.md:76
+msgid ""
+"one or more `locations`, which can be expressed in a variety of ways as "
+"[outlined in the schema reference](../../reference/schema/#location). In "
+"this example, one location is given: a motorway junction, using a point "
+"location, a gazetteer entry and an address."
+msgstr ""
+"uno o más `locations` (ubicaciones), que pueden ser expresadas de diferentes"
+" maneras como se [indica en la referencia del "
+"esquema](../../reference/schema/#location). En este ejemplo, se proporciona "
+"una ubicación: un cruce de autopistas, usando un punto de ubicación, una "
+"entrada de un diccionario geográfico y una dirección."
+
+#: ../../docs/guidance/example.md:95
+msgid "Budget and budget breakdown"
+msgstr "Presupuesto y desglose del presupuesto"
+
+#: ../../docs/guidance/example.md:97
+msgid ""
+"The `budget` section can be used to provide the overall budget for the "
+"project, and its `budgetBreakdown` array can be used to provide a breakdown "
+"of the budget by period and/or funding source."
+msgstr ""
+"La sección de `budget` (presupuesto) puede ser usada para proveer el "
+"presupuesto global para el proyecto, y su array `budgetBreakdown` (desglose "
+"del presupuesto) puede ser usado para proveer un desglose del presupuesto "
+"por periodo y/o fuente de financiamiento. "
+
+#: ../../docs/guidance/example.md:99
+msgid ""
+"In the budget example below, the overall budget for the infrastructure "
+"project covers 3 years and is broken down into amounts per year, with "
+"£10,000,000 allocated in 2016 – as highlighted in the budgetBreakdown "
+"example."
+msgstr ""
+"En el ejemplo de presupuesto de abajo, el presupuesto global para el "
+"proyecto de infraestructura cubre 3 años y está dividido en montos por año, "
+"con £10,000,000 asignados en el 2016 – como está resaltado en el ejemplo de "
+"budgetBreakdown."
+
+#: ../../docs/guidance/example.md:119
+msgid "Parties (organizations)"
+msgstr "Partes (organizaciones, instituciones)"
+
+#: ../../docs/guidance/example.md:121
+msgid ""
+"The `parties` array is used to provide details about organizations involved "
+"in the infrastructure project and their roles. Organization references "
+"elsewhere in the data refer back to entries in this section."
+msgstr ""
+"El array de `parties` (partes) es usado para proveer detalles sobre las "
+"organizaciones involucradas en el proyecto de infraestructura y sus roles. "
+"Las referencias de organización en otros lugares de los datos hacen "
+"referencia a las entradas en esta sección."
+
+#: ../../docs/guidance/example.md:123
+msgid ""
+"In the party example below, details are given about the fictional Motorways "
+"UK entity, which is referred to from the `sourceParty` section in the "
+"`budgetBreakdown` example above, using the `name` and `id` from the entry in"
+" the `parties` array."
+msgstr ""
+"En el ejemplo de partes más abajo, se proporcionan detalles sobre la entidad"
+" ficticia Motorways UK, la cual es referenciada desde la sección "
+"`sourceParty` en el ejemplo de `budgetBreakdown` arriba, usando el `name` "
+"(nombre) y `id` de la entrada en el array de `parties`."
+
+#: ../../docs/guidance/example.md:134
+msgid "Public authority"
+msgstr "Autoridad pública"
+
+#: ../../docs/guidance/example.md:136
+msgid ""
+"The `publicAuthority` field indicates the project owner: the unit, body or "
+"department within a government that is tendering and contracting the "
+"project. It refers to an entry in the `parties` array, as described above."
+msgstr ""
+"El campo `publicAuthority` (autoridad pública) indica quién es el dueño del "
+"proyecto: la unidad, órgano o departamento dentro del gobierno que está "
+"licitando y contratando el proyecto. Hace referencia  a una entrada en el "
+"array de `parties`, como se describe arriba."
+
+#: ../../docs/guidance/example.md:146
+msgid "Documents"
+msgstr "Documentos"
+
+#: ../../docs/guidance/example.md:148
+msgid ""
+"The `documents` array is used to provide information and links to documents "
+"and documentation relating to the infrastructure project. During different "
+"phases of the project, different document types are expected."
+msgstr ""
+"El array de `documents` (documentos) es usado para  proveer información y "
+"enlaces a documentos y documentación relacionada al proyecto de "
+"infraestructura. Durante diferentes fases del proyecto, se esperan "
+"diferentes tipos de documento."
+
+#: ../../docs/guidance/example.md:150
+msgid ""
+"In the document example below, an environmental impact assessment is "
+"provided. The `documentType` field is used to categorize the document "
+"against the [Document Type "
+"codelist](../../reference/codelists/#documenttype)."
+msgstr ""
+"En el ejemplo de documento de abajo, se provee una evaluación de impacto "
+"ambiental. El campo `documentType` (tipo de documento) se usa para "
+"categorizar el documento de acuerdo a la [lista de códigos de Tipo de "
+"Documento](../../reference/codelists/#documenttype)."
+
+#: ../../docs/guidance/example.md:161
+msgid "Contracting processes"
+msgstr "Procesos de contratación"
+
+#: ../../docs/guidance/example.md:163
+msgid ""
+"The `contractingProcesses` array is used to provide information about each "
+"contracting process associated with the project, including summary "
+"information, a list of modifications and a list of OCDS releases."
+msgstr ""
+"La lista `contractingProcesses` se usa para proveer información sobre cada "
+"proceso de contratación asociado con el proyecto, incluyendo información de "
+"resumen, una lista de modificaciones y una lista de \"releases\" OCDS."
+
+#: ../../docs/guidance/example.md:165
+msgid ""
+"In the contractingProcess example below, information is given about a "
+"contracting process for the design of the motorway upgrade, with one related"
+" document in the `documents` array (a tender notice) and two related OCDS "
+"`releases` (one for the tender and one for the contract award)."
+msgstr ""
+"En el ejemplo de contractingProcess de abajo, se proporciona información "
+"sobre un proceso de contratación para el diseño de la mejora del cruce de "
+"autopistas, con un documento relacionado en el array de `documents` (un "
+"aviso de licitación) y dos releases OCDS relacionados (uno para la "
+"licitación y otro para la adjudicación del contrato)."
+
+#: ../../docs/guidance/example.md:176
+msgid "Modifications"
+msgstr "Modificaciones"
+
+#: ../../docs/guidance/example.md:178
+msgid ""
+"Each contracting process includes a `modifications` array which is used to "
+"list any changes to the duration, price, scope or other significant aspect "
+"of the contracting process."
+msgstr ""
+"Cada proceso de contratación incluye una lista de `modifications` "
+"(modificaciones) que es usada para detallar los cambios a la duración, "
+"precio, alcance u otro aspecto significativo del proceso de contratación."
+
+#: ../../docs/guidance/example.md:180
+msgid ""
+"In the modification example below, a change in duration is shown, using the "
+"`oldContractPeriod` and `newContractPeriod` fields."
+msgstr ""
+"En el ejemplo de modificación de abajo, se muestra un cambio en la duración,"
+" usando los campos `oldContractPeriod` y `newContractPeriod`."
+
+#: ../../docs/guidance/example.md:191
+msgid "Completion"
+msgstr "Finalización"
+
+#: ../../docs/guidance/example.md:193
+msgid ""
+"The `completion` section provides final details of the scope, duration and "
+"cost for the project."
+msgstr ""
+"La sección `completion` (finalización) provee los detalles finales del "
+"alcance, duración y costo para el proyecto."
+
+#: ../../docs/guidance/example.md:195
+msgid ""
+"Since in this example there were variations to related contracting "
+"processes, the `finalValue` of the project exceeds its original planned "
+"budget."
+msgstr ""
+"Dado que en este ejemplo hubo variaciones a procesos de contratación "
+"relacionados, el valor final (`finalValue`) del proyecto excede el "
+"presupuesto planeado originalmente."

--- a/locale/es/LC_MESSAGES/guidance/identifiers.po
+++ b/locale/es/LC_MESSAGES/guidance/identifiers.po
@@ -1,0 +1,323 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/identifiers.md:1
+msgid "Project identifiers"
+msgstr "Identificadores de proyecto"
+
+#: ../../docs/guidance/identifiers.md:3
+msgid ""
+"A project identifier is a unique identifier for an infrastructure project. "
+"Every project in OC4IDS has a project identifier in the `id` field."
+msgstr ""
+"Un identificador de proyecto es un identificador único para un proyecto de "
+"infraestructura. Cada proyecto en OC4IDS tiene un identificador de proyecto "
+"en el campo `id`."
+
+#: ../../docs/guidance/identifiers.md:5
+msgid ""
+"Project identifiers can be used to join up data published at different times"
+" or from different systems; for example, including a project identifier in "
+"contracting data makes it possible to join up data on the design, "
+"construction and supervision contracts within a single infrastructure "
+"project."
+msgstr ""
+"Los identificadores de proyecto pueden usarse para unir datos publicados en "
+"momentos diferentes o por sistemas diferentes; por ejemplo, incluyendo un "
+"identificador de proyecto en los datos de contratación hace posible unir "
+"datos de los contratos de diseño, construcción y supervisión dentro de un "
+"solo proyecto de infraestructura."
+
+#: ../../docs/guidance/identifiers.md:7
+msgid "Local project identifiers in contracting data"
+msgstr "Identificadores de proyectos locales en datos de contrataciones"
+
+#: ../../docs/guidance/identifiers.md:9
+msgid ""
+"A common need is to access data about the contracting processes related to "
+"an infrastructure project. When contracting systems use consistent "
+"identifiers to refer to infrastructure projects, this becomes possible. An "
+"example use case is automatically checking which projects have related "
+"contracting data, and then manually filtering projects for further scrutiny,"
+" monitoring or data collection."
+msgstr ""
+"Una necesidad común es la de acceder a datos sobre procesos de contratación "
+"relacionados a un proyecto de infraestructura. Cuando los sistemas de "
+"contrataciones usan identificadores consistentes para referirse a proyectos "
+"de infraestructura, esto se vuelve posible. Un caso de uso de ejemplo es "
+"verificar automáticamente qué proyectos tienen datos de contrataciones "
+"relacionadas, y luego filtrar manualmente estos proyectos para análisis "
+"posteriores, monitoreo o recolección de datos."
+
+#: ../../docs/guidance/identifiers.md:11
+msgid ""
+"Project identifiers in contracting data should be locally unique; this means"
+" that across all contracting data from a particular system or country, each "
+"project identifier refers to exactly one infrastructure project."
+msgstr ""
+"Los identificadores de proyecto usados en datos de contrataciones deberían "
+"ser únicos localmente; esto quiere decir que cada identificador de proyecto "
+"se refiere exactamente a un proyecto de infraestructura mediante todos los "
+"datos de contrataciones de un sistema o país en particular."
+
+#: ../../docs/guidance/identifiers.md:13
+msgid ""
+"There are different approaches to including project identifiers in "
+"contracting data, with the best solution depending on the context of an "
+"implementation:"
+msgstr ""
+"Existen diferente enfoques para incluir identificadores de proyecto en datos"
+" de contrataciones, y la mejor solución depende del contexto de una "
+"implementación:"
+
+#: ../../docs/guidance/identifiers.md:15
+msgid ""
+"**Include a free-text field for project identifiers in procurement systems**"
+" and work with officials entering procurement information to make sure this "
+"is populated according to a defined pattern."
+msgstr ""
+"**Incluya un campo de texto libre para identificadores de proyectos en "
+"sistemas de adquisiciones** y trabaje con los funcionarios que ingresan la "
+"información de adquisiciones para asegurar que este es llenado de acuerdo a "
+"un patrón definido."
+
+#: ../../docs/guidance/identifiers.md:17
+msgid ""
+"Free-text entry of project identifiers can lead to data quality issues; for "
+"example, project identifiers can be mistyped or two groups can accidentally "
+"choose to use the same identifier for different projects."
+msgstr ""
+"La entrada de texto libre en identificadores de proyectos puede llevar a "
+"problemas de calidad de datos; por ejemplo, los identificadores de proyecto "
+"pueden ser ingresados incorrectamente o dos grupos pueden elegir, "
+"accidentalmente, usar el mismo identificador para diferentes proyectos."
+
+#: ../../docs/guidance/identifiers.md:19
+msgid ""
+"However, this approach allows some data quality checks to be run; for "
+"example, checking that all the contracting processes over a certain value "
+"from a given agency have a project identifier, and that the identifier "
+"matches a defined pattern or a local list of project identifiers."
+msgstr ""
+"Sin embargo, este enfoque permite correr algunas verificaciones de calidad "
+"de datos; por ejemplo, para verificar si todos los procesos de contratación "
+"por encima de un cierto valor y para cierta entidad tienen un identificador "
+"de proyecto, y si ese identificador coincide con un patrón determinado o con"
+" una entrada en una lista local de identificadores de proyecto."
+
+#: ../../docs/guidance/identifiers.md:21
+msgid ""
+"This approach also enables the joining up of data on multiple contracting "
+"processes relating to a single infrastructure project."
+msgstr ""
+"Este enfoque también permite unir datos de múltiples procesos de "
+"contratación relacionados a un solo proyecto de infraestructura."
+
+#: ../../docs/guidance/identifiers.md:24
+msgid ""
+"**Establish a national project register managed by a central agency and "
+"integrated into procurement systems.** In this model, officials entering "
+"procurement information would look up and use the project's identifier from "
+"the national register. If the project is not yet in the register, they would"
+" request its addition."
+msgstr ""
+"**Establecer un registro nacional de proyectos administrado por una agencia "
+"central e integrado a los sistemas de adquisiciones.** En este modelo, los "
+"funcionarios que ingresan información de adquisiciones buscarían y usarían "
+"el identificador de proyecto proveniente del registro nacional. Si el "
+"proyecto aún no está en el registro, ellos podrían solicitar su adición."
+
+#: ../../docs/guidance/identifiers.md:26
+msgid ""
+"This approach supports more comprehensive and effective data quality checks;"
+" for example, project identifiers entered into procurement systems can be "
+"immediately checked against the project register to prevent errors in data "
+"entry (\"validation at source\")."
+msgstr ""
+"Este enfoque apoya verificaciones de calidad de datos más completas y "
+"efectivas; por ejemplo, los identificadores de proyecto ingresados en "
+"sistemas de adquisiciones pueden ser verificados inmediatamente con el "
+"registro de proyectos para prevenir errores en la entrada de datos "
+"(\"validation at source\")."
+
+#: ../../docs/guidance/identifiers.md:28
+msgid ""
+"A central register can ensure that project identifiers are locally unique, "
+"and more robustly supports use cases like identifying projects lacking "
+"related contracts."
+msgstr ""
+"Un registro central puede asegurar que los identificadores de proyecto son "
+"localmente únicos, y apoyar de forma más robusta casos de uso tales como "
+"identificar proyectos que no tienen contratos relacionados."
+
+#: ../../docs/guidance/identifiers.md:30
+msgid ""
+"However, this approach requires political will and technical capacity to "
+"establish the central register and integrate it into procurement systems, "
+"and it requires an appropriate central actor to manage it."
+msgstr ""
+"Sin embargo, este enfoque requiere capacidad política y técnica para "
+"establecer el registro central e integrarlo en los sistemas de "
+"adquisiciones, y requiere un actor central apropiado para administrarlo."
+
+#: ../../docs/guidance/identifiers.md:32
+msgid "Project identifiers in OCDS"
+msgstr "Identificadores de proyecto en OCDS"
+
+#: ../../docs/guidance/identifiers.md:34
+msgid ""
+"In OCDS, the identifier for the individual infrastructure project to which a"
+" contracting process is related should be disclosed using the "
+"`planning/project/id` field, introduced in the [Budget and Projects "
+"extension](https://extensions.open-"
+"contracting.org/en/extensions/budget_project/)."
+msgstr ""
+"En OCDS, el identificador del proyecto de infraestructura individual al cual"
+" está relacionado un proceso de contratación debería ser divulgado usando el"
+" campo `planning/project/id`, presentado en la [extensión de Presupuestos y "
+"Proyectos](https://extensions.open-"
+"contracting.org/es/extensions/budget_project/)."
+
+#: ../../docs/guidance/identifiers.md:36
+msgid ""
+"The `planning/budget/projectID` field in OCDS should **not** be used to "
+"disclose the identifier for an individual infrastructure project. This field"
+" is used to disclose the identifier for a project in the national budget to "
+"which the contracting process is related. Since projects in the national "
+"budget might include many individual infrastructure projects, it is "
+"necessary to disclose these identifiers separately."
+msgstr ""
+"El campo `planning/budget/projectID` de OCDS **no** debería ser usado para "
+"divulgar el identificador de un proyecto de infraestructura individual. Este"
+" campo es usado para divulgar el identificador de un proyecto en el "
+"presupuesto nacional al cual el proceso de contratación está relacionado. Ya"
+" que los proyectos en el presupuesto nacional pueden incluir varios "
+"proyectos de infraestructura individuales, es necesario divulgar estos "
+"identificadores separadamente."
+
+#: ../../docs/guidance/identifiers.md:38
+msgid "Project identifier prefixes"
+msgstr "Prefijos de identificador de proyecto"
+
+#: ../../docs/guidance/identifiers.md:40
+msgid ""
+"Project identifiers in OC4IDS should be globally unique; this means that, "
+"across all the data of all OC4IDS publishers, each project identifier refers"
+" to exactly one infrastructure project."
+msgstr ""
+"Los identificadores de proyecto en OC4IDS deberían ser globalmente únicos; "
+"esto significa que, a través de todos los datos de todos los publicadores de"
+" OC4IDS, cada identificador de proyecto se refiere a exactamente un proyecto"
+" de infraestructura."
+
+#: ../../docs/guidance/identifiers.md:42
+msgid ""
+"If local project identifiers are available in existing systems or data, "
+"these should be re-used to create globally unique project identifiers for "
+"use in OC4IDS. Otherwise, if local project identifiers are not available, "
+"publishers may assign local identifiers to projects in the new systems used "
+"to generate OC4IDS data."
+msgstr ""
+"Si hay identificadores locales de proyecto disponibles en sistemas o datos "
+"existentes, estos deberían ser reutilizados para crear identificadores de "
+"proyecto globalmente únicos para su uso en OC4IDS. De otra forma, si no hay "
+"identificadores locales de proyecto disponibles, los publicadores pueden "
+"asignar identificadores locales a los proyectos en los nuevos sistemas "
+"usados para generar datos OC4IDS."
+
+#: ../../docs/guidance/identifiers.md:44
+msgid ""
+"To make local project identifiers globally unique for use in OC4IDS, a "
+"publisher requests a project identifier prefix from the [OC4IDS "
+"Helpdesk](mailto:data@open-contracting.org). The publisher must then use the"
+" assigned prefix in all its project identifiers, according to following "
+"structure: `[project identifier prefix]-[local project identifier]`."
+msgstr ""
+"Para hacer que los identificadores locales sean globalmente únicos para su "
+"uso en OC4IDS, un publicador solicita un prefijo de identificador de "
+"proyecto al [Helpdesk de OC4IDS](mailto:data@open-contracting.org). El "
+"publicador debe usar el prefijo asignado en todos sus identificadores de "
+"proyecto, de acuerdo a la estructura que sigue: `[prefijo de identificador "
+"de proyecto]-[identificador local de proyecto]`."
+
+#: ../../docs/guidance/identifiers.md:46
+msgid ""
+"For example: CoST Honduras requests a project identifier prefix from the "
+"OC4IDS Helpdesk. The OC4IDS Helpdesk assigns the randomly-generated prefix "
+"`oc4ids-qu8r7p`. CoST Honduras then creates globally unique project "
+"identifiers, by combining its assigned prefix with each local project "
+"identifier from its SISOCS system."
+msgstr ""
+"Por ejemplo: CoST Honduras solicita un prefijo de identificador de proyecto "
+"al Helpdesk de OC4IDS. El Helpdesk de OC4IDS le asigna el prefijo `oc4ids-"
+"qu8r7p` generado de forma aleatoria. Entonces CoST Honduras genera "
+"identificadores de proyecto globalmente únicos, combinando su prefijo "
+"asignado con cada identificador de proyecto local proveniente de su sistema "
+"SISOCS."
+
+#: ../../docs/guidance/identifiers.md:48
+msgid ""
+"Project identifier prefixes are typically unique to each publisher. However,"
+" multiple publishers in the same jurisdiction can collaboratively decide to "
+"use the same project identifier prefix: for example, if multiple agencies "
+"are independently responsible for different projects. As such, the prefix "
+"serves to identify a series of infrastructure projects (to which many "
+"publishers can contribute), rather than to identify one publisher."
+msgstr ""
+"Típicamente, los prefijos de identificador de proyecto son únicos para cada "
+"publicador. Sin embargo, múltiples publicadores en la misma jurisdicción "
+"pueden decidir colaborativamente usar el mismo prefijo de identificador de "
+"proyecto: por ejemplo, si varias agencias son independientemente "
+"responsables de diferentes proyectos. Así, el prefijo sirve para identificar"
+" una serie de proyectos de infraestructura (para la cual varios publicadores"
+" pueden contribuir) en lugar de identificar un solo publicador."
+
+#: ../../docs/guidance/identifiers.md:1
+msgid "Request a project identifier prefix"
+msgstr "Solicitar un prefijo de identificador de proyecto"
+
+#: ../../None:1
+msgid ""
+"To request a project identifier prefix, please e-mail [data@open-"
+"contracting.org](mailto:data@open-contracting.org) with the name of your "
+"organization and a brief description of your OC4IDS implementation."
+msgstr ""
+"Para solicitar un prefijo de identificador de proyecto, favor escriba un "
+"email a [data@open-contracting.org](mailto:data@open-contracting.org) con el"
+" nombre de su organización y una breve descripción de su implementación "
+"OC4IDS."
+
+#: ../../docs/guidance/identifiers.md:60
+msgid "Existing prefixes"
+msgstr "Prefijos existentes"
+
+#: ../../docs/guidance/identifiers.md:62
+msgid ""
+"The list below shows all registered prefixes. You can [download the list as "
+"CSV](https://docs.google.com/spreadsheets/d/e/2PACX-"
+"1vTWtoIa_26k35bmZVGiAziNMvdUgDS93ZM2j99XidgHaoQxm9C2dbnblckB0ZF7NUKJ6RrpDS7OQvxl/pub?gid=506986894&single=true&output=csv)."
+msgstr ""
+"La lista de abajo muestra todos los prefijos registrados. Puede [descargar "
+"la lista en formato CSV](https://docs.google.com/spreadsheets/d/e/2PACX-"
+"1vTWtoIa_26k35bmZVGiAziNMvdUgDS93ZM2j99XidgHaoQxm9C2dbnblckB0ZF7NUKJ6RrpDS7OQvxl/pub?gid=506986894&single=true&output=csv)."

--- a/locale/es/LC_MESSAGES/guidance/index.po
+++ b/locale/es/LC_MESSAGES/guidance/index.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2019\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/index.md:1
+msgid "Implementation guidance"
+msgstr "Guía de Implementación"

--- a/locale/es/LC_MESSAGES/guidance/publishing.po
+++ b/locale/es/LC_MESSAGES/guidance/publishing.po
@@ -1,0 +1,358 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/publishing.md:1
+msgid "Publishing data from an infrastructure transparency portal"
+msgstr "Publicando datos desde un portal de transparencia en infraestructura"
+
+#: ../../docs/guidance/publishing.md:3
+msgid ""
+"OC4IDS can be used to publish standardized open data on infrastructure "
+"projects where information is already collected and disclosed through "
+"infrastructure transparency portals, whether by CoST Multi-Stakeholder "
+"Groups, government agencies or civil society organizations."
+msgstr ""
+"OC4IDS puede ser usado para publicar datos abiertos estandarizados sobre "
+"proyectos de infraestructura donde la información ya es recolectada y "
+"divulgada a través de portales de transparencia en infraestructura, ya sea "
+"por grupos multisectoriales de CoST, agencias del gobierno u organizaciones "
+"de la sociedad civil."
+
+#: ../../docs/guidance/publishing.md:5
+msgid ""
+"Publishing standardized open data reduces barriers to use of data and "
+"supports the development of reusable tools and methodologies for working "
+"with data on infrastructure projects."
+msgstr ""
+"Publicar datos abiertos estandarizados reduce las barreras de uso de datos y"
+" apoya el desarrollo de herramientas y metodologías reutilizables para "
+"trabajar con datos de proyectos de infraestructura."
+
+#: ../../docs/guidance/publishing.md:7
+msgid ""
+"If you also collect detailed data on contracting processes, this can be "
+"published using the [Open Contracting Data Standard (OCDS)](https://standard"
+".open-contracting.org/1.1/en/)."
+msgstr ""
+"Si usted también recolecta datos detallados sobre procesos de contratación, "
+"estos pueden ser publicados usando el [Estándar de Datos de Contrataciones "
+"Abiertas (OCDS, por sus siglas en inglés)](https://standard.open-"
+"contracting.org/1.1/en/)."
+
+#: ../../docs/guidance/publishing.md:1
+msgid "Linking to related information"
+msgstr "Enlaces a información relacionada"
+
+#: ../../None:1
+msgid ""
+"Infrastructure transparency portal creators should consider what other types"
+" of information might be important to citizens, in addition to the in depth "
+"scrutiny related information in OC4IDS."
+msgstr ""
+"Los creadores de portales de transparencia en infraestructura deberían "
+"considerar qué otros tipos de información podrían ser importantes para los "
+"ciudadanos, además de la información detallada en OC4IDS que permite un "
+"escrutinio profundo."
+
+#: ../../None:3
+msgid ""
+"For example, [Highways England](https://highwaysengland.co.uk/roads/) "
+"provides links to congestion and traffic restriction information alongside "
+"information on roads projects."
+msgstr ""
+"Por ejemplo, [Highways England](https://highwaysengland.co.uk/roads/) provee"
+" información sobre congestiones y restricciones en el tráfico además de "
+"información sobre proyectos de rutas."
+
+#: ../../docs/guidance/publishing.md:21
+msgid "Getting started"
+msgstr "Para empezar"
+
+#: ../../docs/guidance/publishing.md:23
+msgid ""
+"*Some of the following steps may require support from a technical expert. "
+"You can also contact the OC4IDS Helpdesk ([data@open-"
+"contracting.org](mailto:data@open-contracting.org)) for guidance.*"
+msgstr ""
+"*Algunos de los pasos siguientes pueden requerir la ayuda de un experto "
+"técnico. Usted también puede contactar con el Helpdesk de OC4IDS ([data"
+"@open-contracting.org](mailto:data@open-contracting.org)) para orientación.*"
+
+#: ../../docs/guidance/publishing.md:25
+msgid "(1) Make a commitment"
+msgstr "(1) Hacer un compromiso"
+
+#: ../../docs/guidance/publishing.md:27
+msgid ""
+"Consider making or advocating for a public commitment to publish "
+"standardized open data using OC4IDS and OCDS."
+msgstr ""
+"Considere hacer o abogar por un compromiso público para publicar datos "
+"abiertos estandarizados usando OC4IDS u OCDS."
+
+#: ../../docs/guidance/publishing.md:29
+msgid ""
+"Commitments are important to help align implementation with the goals of "
+"publishing open data and to help overcome technical, political or "
+"bureaucratic barriers to publication."
+msgstr ""
+"Los compromisos son importantes para ayudar a alinear la implementación con "
+"los objetivos de la publicación de datos abiertos y para ayudar a superar "
+"barreras técnicas, políticas o burocráticas a la publicación."
+
+#: ../../docs/guidance/publishing.md:31
+msgid ""
+"Applications to join [CoST](http://infrastructuretransparency.org/) can be "
+"used to make a commitment or if your country is a member of the [Open "
+"Government Partnership](https://www.opengovpartnership.org/), your National "
+"Action Plan is another great place to start."
+msgstr ""
+"Las solicitudes para adherirse a "
+"[CoST](http://infrastructuretransparency.org/) pueden usarse para realizar "
+"un compromiso, o si su país es un miembro de la [Open Government "
+"Partnership](https://www.opengovpartnership.org/), su Plan de Acción "
+"Nacional es otro buen lugar para empezar."
+
+#: ../../docs/guidance/publishing.md:33
+msgid ""
+"Refer to the [OCDS implementation journey](https://www.open-"
+"contracting.org/implement/#/1) for information and resources about making "
+"commitments related to OCDS. Refer to the [CoST and OGP guidance "
+"note](http://infrastructuretransparency.org/wp-content/uploads/2018/07"
+"/Guidance-Note-CoST-and-OGP-.pdf) for guidance on making OGP commitments "
+"related to CoST."
+msgstr ""
+"Vea el [recorrido de implementación OCDS](https://www.open-"
+"contracting.org/es/implement/) para información y recursos sobre cómo hacer "
+"compromisos relacionados a OCDS. Consulte la [nota de guía de CoST y "
+"OGP](http://infrastructuretransparency.org/wp-content/uploads/2018/07/GN-"
+"Spanish-CoSTOGP-WebV2.pdf) para orientación sobre cómo hacer compromisos OGP"
+" relacionados a CoST."
+
+#: ../../docs/guidance/publishing.md:35
+msgid "(2a) Map project-level data and summary contracting process data"
+msgstr ""
+"(2a) Mapear datos a nivel de proyecto y datos de resumen de procesos de "
+"contratación"
+
+#: ../../docs/guidance/publishing.md:37
+msgid "Map existing data structures to [OC4IDS](../../projects/index)."
+msgstr ""
+"Mapee estructuras de datos existentes a [OC4IDS](../../projects/index)."
+
+#: ../../docs/guidance/publishing.md:1 ../../docs/guidance/publishing.md:1
+#: ../../docs/guidance/publishing.md:1
+msgid "Tip"
+msgstr "Consejo"
+
+#: ../../None:1
+msgid ""
+"The [OC4IDS Field-Level Mapping "
+"Template](https://docs.google.com/spreadsheets/d/1xHLf_w193pp97zfzhLc_LI-"
+"yEXrR_eyscga06Qo1blk/copy) can be used to document your mapping."
+msgstr ""
+"La [plantilla de mapeo a nivel de campos "
+"OC4IDS](https://docs.google.com/spreadsheets/d/1xHLf_w193pp97zfzhLc_LI-"
+"yEXrR_eyscga06Qo1blk/copy) puede ser usada para documentar el mapeo."
+
+#: ../../docs/guidance/publishing.md:49
+msgid "Your mapping might identify:"
+msgstr "Su mapeo puede identificar:"
+
+#: ../../docs/guidance/publishing.md:51
+msgid ""
+"**Gaps in your data** where data in OC4IDS is not currently collected or "
+"disclosed in your system. Use OC4IDS as a guide to the information that is "
+"important to users and consider whether your system and business processes "
+"could be updated to collect and publish additional information."
+msgstr ""
+"**Faltantes en sus datos** donde datos en OC4IDS no están siendo "
+"recolectados o publicados en su sistema. Use OC4IDS como una guía a la "
+"información que es importante para los usuarios y considere si su sistema y "
+"procesos de negocio pueden ser actualizados para recolectar y publicar "
+"información adicional."
+
+#: ../../docs/guidance/publishing.md:53
+msgid ""
+"**Gaps in OC4IDS** where data is collected by your system but doesn't map to"
+" OC4IDS. Rather than being excluded from your publication, such information "
+"should be included as additional fields in your data. Refer to [extending "
+"the schema](../../reference/#extending-the-schema) for information on "
+"including additional fields in your data."
+msgstr ""
+"**Brechas en OC4IDS** donde los datos son recoletados por su sistema pero no"
+" tienen un mapeo a OC4IDS. En lugar de excluirlos de su publicación, esa "
+"información debería ser incluida como campos adicionales en sus datos. Vea "
+"la sección de [extendiendo el esquema](../../reference/#extending-the-"
+"schema) para información sobre cómo incluir campos adicionales en sus datos."
+
+#: ../../docs/guidance/publishing.md:56
+msgid "(2b) Map detailed contracting process data"
+msgstr "(2b) Mapear datos detallados de procesos de contratación"
+
+#: ../../docs/guidance/publishing.md:58
+msgid ""
+"If you collect detailed data on contracting processes, refer to the [OCDS "
+"implementation journey](https://www.open-contracting.org/implement/#/2) for "
+"information and resources about mapping and publishing your contracting data"
+" using OCDS."
+msgstr ""
+"Si usted recolecta datos detallados sobre procesos de contratación, vea el "
+"[viaje de implementación OCDS](https://www.open-"
+"contracting.org/implement/#/2) para información y recursos sobre cómo mapear"
+" y publicar sus datos de contrataciones usando OCDS."
+
+#: ../../docs/guidance/publishing.md:60
+msgid ""
+"Include an identifier for the infrastructure project that each contracting "
+"process relates to in your OCDS data, following the guidance on [project "
+"identifiers in OCDS](../identifiers/#project-identifiers-in-ocds)."
+msgstr ""
+"Incluya un identificador para el proyecto de infraestructura al cual se "
+"relaciona cada proceso de contratación en sus datos OCDS, siguiendo la guía "
+"en [identificadores de proyecto en OCDS](../identifiers/#project-"
+"identifiers-in-ocds)."
+
+#: ../../docs/guidance/publishing.md:62
+msgid "(3) Build your data, systems and processes"
+msgstr "(3) Construir sus datos, sistemas y procesos"
+
+#: ../../docs/guidance/publishing.md:64
+msgid ""
+"Create an OC4IDS JSON file for each project your system has information on "
+"and use the [OC4IDS Data Review Tool](https://standard.open-"
+"contracting.org/infrastructure/review/) to check that the files are "
+"structurally correct against OC4IDS."
+msgstr ""
+"Cree un archivo OC4IDS JSON por cada proyecto del cual su sistema tenga "
+"información y use la [Herramienta de revisión de datos "
+"OC4IDS](https://standard.open-contracting.org/infrastructure/review/) para "
+"comprobar que los archivos son estructuralmente correctos de acuerdo a "
+"OC4IDS."
+
+#: ../../None:1
+msgid ""
+"You can use a [blank example OC4IDS JSON file](../../_static/blank.json) to "
+"get started."
+msgstr ""
+"Puede usar un [archivo de ejemplo OC4IDS JSON en "
+"blanco](../../_static/blank.json) para empezar."
+
+#: ../../docs/guidance/publishing.md:76
+msgid ""
+"If you are also publishing contracting data using OCDS, create an OCDS "
+"release each time the data about a contracting process changes and use the "
+"[OCDS Data Review Tool](https://standard.open-contracting.org/review/) to "
+"check your OCDS releases."
+msgstr ""
+"Si también está publicando datos de contrataciones usando OCDS, cree un "
+"release OCDS cada vez que los datos sobre el proceso de contratación cambien"
+" y use la [Herramienta de revisión de datos OCDS](https://standard.open-"
+"contracting.org/review/) para verificar sus releases OCDS."
+
+#: ../../docs/guidance/publishing.md:78
+msgid ""
+"Make sure you have systems and/or business processes in place to keep the "
+"data you produce up to date."
+msgstr ""
+"Asegúrese de que existen los sistemas y/o procesos de negocio necesarios "
+"para mantener actualizados los datos que produce."
+
+#: ../../docs/guidance/publishing.md:80
+msgid "(4) Publish your data"
+msgstr "(4) Publicar sus datos"
+
+#: ../../docs/guidance/publishing.md:82
+msgid ""
+"Publish your OC4IDS JSON fields (as either static files or via an API) at a "
+"stable URL, such as:"
+msgstr ""
+"Publique sus campos JSON OC4IDS (ya sea como archivos estáticos o a través "
+"de una API) en una URL estable, tal como:"
+
+#: ../../docs/guidance/publishing.md:84
+msgid "http://{your website}/opendata/projects/{project-id}.json"
+msgstr "http://{su sitio}/opendata/projects/{project-id}.json"
+
+#: ../../docs/guidance/publishing.md:86
+msgid ""
+"If you are also publishing contracting data using OCDS, publish each new "
+"release of data as a JSON file at a stable URL such as:"
+msgstr ""
+"Si también está publicando datos de contrataciones usando OCDS, publique "
+"cada \"release\" nuevo de datos como un archivo JSON en una URL estable tal "
+"como:"
+
+#: ../../docs/guidance/publishing.md:88
+msgid "http://{your website}/opendata/contracting/{ocid}/{release-id}.json"
+msgstr "http://{your website}/opendata/contracting/{ocid}/{release-id}.json"
+
+#: ../../docs/guidance/publishing.md:90
+msgid ""
+"Make sure your project-level files include links in the "
+"`contractingProcesses/releases` section to each related OCDS file."
+msgstr ""
+"Asegúrese de que sus archivos a nivel de proyecto incluyan enlaces a los "
+"archivos OCDS relacionados en la sección `contractingProcesses/releases`."
+
+#: ../../docs/guidance/publishing.md:92
+msgid "To make your data easier to access, consider providing:"
+msgstr ""
+"Para hacer que sus datos sean más fáciles de acceder, considere proveer:"
+
+#: ../../docs/guidance/publishing.md:94
+msgid "A regularly updated bulk file of all your data for download"
+msgstr ""
+"Un archivo masivo actualizado regularmente con todos sus datos para "
+"descargar"
+
+#: ../../docs/guidance/publishing.md:95
+msgid "Flattened (spreadsheet or CSV) representations of your data"
+msgstr "Representaciones serializadas de sus datos (hojas de cálculo o CSV)"
+
+#: ../../docs/guidance/publishing.md:96
+msgid "A page on your website with details of how users can access your data"
+msgstr ""
+"Una página en su sitio Web con detalles sobre cómo los usuarios pueden "
+"acceder a los datos."
+
+#: ../../None:1
+msgid ""
+"[Flatten-tool](https://flatten-tool.readthedocs.io/en/latest/) can be used "
+"to convert between JSON and spreadsheet/CSV format data."
+msgstr ""
+"El [flatten-tool](https://flatten-tool.readthedocs.io/en/latest/) puede ser "
+"usado para conversiones entre los formatos JSON y hojas de cálculo/CSV."
+
+#: ../../docs/guidance/publishing.md:108
+msgid ""
+"Refer to the [OCDS documentation](https://standard.open-"
+"contracting.org/1.1/en/implementation/hosting/#data-files-apis-and-"
+"discovery) for more information on providing data in multiple formats."
+msgstr ""
+"Consulte la [documentación de OCDS](https://standard.open-"
+"contracting.org/1.1/es/implementation/hosting/#data-files-apis-and-"
+"discovery) para más información sobre cómo proveer datos en múltiples "
+"formatos."

--- a/locale/es/LC_MESSAGES/guidance/using.po
+++ b/locale/es/LC_MESSAGES/guidance/using.po
@@ -1,0 +1,482 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/guidance/using.md:1
+msgid "Using data from procurement systems for infrastructure monitoring"
+msgstr ""
+"Usando datos de sistemas de adquisiciones para monitoreo de proyectos de "
+"infraestructura"
+
+#: ../../docs/guidance/using.md:3
+msgid ""
+"An increasing number of procurement portals now publish data using the Open "
+"Contracting Data Standard (OCDS). When OCDS is implemented in full, then:"
+msgstr ""
+"Cada vez más portales de adquisiciones publican datos usando el Estándar de "
+"Datos de Contrataciones Abiertas (OCDS). Cuando OCDS está implementado "
+"completamente:"
+
+#: ../../docs/guidance/using.md:5
+msgid "Each contracting process is given a unique identifier (`ocid`);"
+msgstr "Cada proceso de contratación tiene un identificador único (`ocid`);"
+
+#: ../../docs/guidance/using.md:7
+msgid ""
+"Every update to that process, from planning through to implementation, "
+"should be published under the same `ocid`, and in a structured open data "
+"format;"
+msgstr ""
+"Cada actualización a ese proceso, desde la planeación hasta la "
+"implementación, debería estar publicado bajo el mismo `ocid`, y en un "
+"formato de datos abiertos estructurado;"
+
+#: ../../docs/guidance/using.md:9
+msgid ""
+"It should be possible to download bulk data in OCDS format, or access this "
+"structured data via an API."
+msgstr ""
+"Debería ser posible descargar datos en masa en formato OCDS, o acceder a "
+"estos datos estructurados por medio de una API."
+
+#: ../../docs/guidance/using.md:11
+msgid ""
+"Even when an OCDS publisher does not provide data for every stage of the "
+"contracting process, it is still possible to use OCDS data to:"
+msgstr ""
+"Incluso cuando un publicador OCDS no provee datos por cada etapa del proceso"
+" de contratación, todavía es posible usar datos OCDS para:"
+
+#: ../../docs/guidance/using.md:13
+msgid "Discover contracts related to infrastructure projects;"
+msgstr "Descubrir contratos relacionados a proyectos de infraestructura;"
+
+#: ../../docs/guidance/using.md:15
+msgid ""
+"Track these contracting processes, including changes to tenders, details of "
+"suppliers selected, and, in some cases, details of contract modifications."
+msgstr ""
+"Hacer seguimiento de estos procesos de contratación, incluyendo cambios a "
+"las licitaciones, detalles de los proveedores seleccionados y, en algunos "
+"casos, detalles de las modificaciones al contrato."
+
+#: ../../docs/guidance/using.md:17
+msgid "Getting started"
+msgstr "Para empezar"
+
+#: ../../docs/guidance/using.md:19
+msgid ""
+"*The following steps may require support from a technical expert. You can "
+"also contact the OC4IDS Helpdesk ([data@open-contracting.org](mailto:data"
+"@open-contracting.org)) for guidance.*"
+msgstr ""
+"*Los siguientes pasos pueden requerir ayuda de un experto técnico. También "
+"puede contactar al \"Helpdesk\" de OC4IDS ([data@open-"
+"contracting.org](mailto:data@open-contracting.org)) para orientación.*"
+
+#: ../../docs/guidance/using.md:21
+msgid "(1) Evaluate the Open Contracting Data"
+msgstr "(1) Evaluar los datos de Contrataciones Abiertas"
+
+#: ../../docs/guidance/using.md:23
+msgid "Check that the data you plan to analyze is in OCDS format"
+msgstr "Verifique que los datos que planea analizar están en formato OCDS"
+
+#: ../../docs/guidance/using.md:1 ../../docs/guidance/using.md:1
+#: ../../docs/guidance/using.md:1 ../../docs/guidance/using.md:1
+#: ../../docs/guidance/using.md:1 ../../docs/guidance/using.md:1
+msgid "Tip"
+msgstr "Consejo"
+
+#: ../../None:1
+msgid ""
+"You can use the [OCDS Data Review Tool](https://standard.open-"
+"contracting.org/review/) to check whether your data is in the correct format"
+msgstr ""
+"Puede usar la [Herramienta de revisión de datos OCDS](https://standard.open-"
+"contracting.org/review/) para verificar si sus datos están en el formato "
+"correcto."
+
+#: ../../docs/guidance/using.md:35
+msgid "Check which stages of the contracting process the data covers."
+msgstr ""
+"Verificar qué etapas del proceso de contratación están cubiertas por los "
+"datos"
+
+#: ../../docs/guidance/using.md:37
+msgid ""
+"Check whether the publisher keeps a change history (multiple releases for "
+"each contracting process), or whether as a user of the data you will need to"
+" keep the change history."
+msgstr ""
+"Verificar si el publicador mantiene un historial de cambios (múltiples "
+"releases por cada proceso de contratación), o si usted como usuario "
+"necesitará mantener un historial de los datos "
+
+#: ../../docs/guidance/using.md:39
+msgid "(2) Identify how you will query the data"
+msgstr "(2) Identificar cómo consultará los datos"
+
+#: ../../docs/guidance/using.md:41
+msgid ""
+"Some OCDS publishers provide an API that can be used to query data. Others "
+"provide access to bulk data that you can download into your own tools for "
+"querying."
+msgstr ""
+"Algunos publicadores OCDS proveen una API que puede ser utilizada para "
+"consultar los datos. Otros proveen acceso a datos en masa que puede "
+"descargar y utilizar con sus herramientas de consulta propias."
+
+#: ../../None:1
+msgid ""
+"If you are working with OCDS data from an unreliable source, consider "
+"caching a copy of the OCDS releases that relate to the infrastructure "
+"projects you are monitoring, and consider linking to the copies from your "
+"OC4IDS data in order to ensure they are available to users."
+msgstr ""
+"Si está trabajando con datos OCDS de una fuente poco fiable, considere "
+"almacenar una copia de los releases OCDS que se relacionan a los proyectos "
+"de infraestructura que está monitoreando, y considere enlazar sus datos "
+"OC4IDS a las copias para asegurar que los releases OCDS estén disponibles "
+"para los usuarios."
+
+#: ../../None:1
+msgid ""
+"[OCDS Kingfisher](https://github.com/open-contracting/kingfisher/) is an "
+"open source tool that can load OCDS data into a PostgreSQL database. It "
+"includes scrapers for many known OCDS data sources"
+msgstr ""
+"[OCDS Kingfisher](https://github.com/open-contracting/kingfisher/) es una "
+"herramienta de código abierto que puede cargar datos OCDS en una base de "
+"datos PostgreSQL. Incluye opciones de descarga para muchas fuentes OCDS "
+"conocidas"
+
+#: ../../docs/guidance/using.md:62
+msgid "(3) Develop a search strategy to discover infrastructure projects"
+msgstr ""
+"(3) Desarrollar una estrategia de búsqueda para descubrir proyectos de "
+"infraestructura"
+
+#: ../../docs/guidance/using.md:64
+msgid ""
+"Ideally, the procurement data source will include some sort of project or "
+"budget identifier fields that relate to a register of infrastructure "
+"projects."
+msgstr ""
+"Idealmente, la fuente de datos de adquisiciones incluirá alguna clase de "
+"campo identificador de proyecto o de presupuesto que esté relacionado a un "
+"registro de proyectos de infraestructura."
+
+#: ../../None:1
+msgid ""
+"If the procurement data you are working with is in OCDS format, refer to the"
+" guidance on [project identifiers in OCDS](identifiers) for more information"
+" on where to find identifiers for projects."
+msgstr ""
+"Si los datos de compras públicas con los cuales trabaja están en formato "
+"OCDS, revise la guía de [identificadores de proyecto en OCDS)[identifiers] "
+"para más información sobre dónde encontrar identificadores de proyecto."
+
+#: ../../docs/guidance/using.md:76
+msgid ""
+"However, where this is not the case, it may be possible to search for "
+"tenders with a particular set of item classifications, or from a particular "
+"buyer."
+msgstr ""
+"Sin embargo, cuando este no sea el caso, puede ser posible buscar "
+"licitaciones con un conjunto particular de clasificaciones de artículos, o "
+"de un comprador en particular."
+
+#: ../../docs/guidance/using.md:78
+msgid ""
+"This may be possible by downloading and filtering spreadsheets of the data, "
+"or may require queries written against your chosen data storage tool."
+msgstr ""
+"Esto debería ser posible descargando y filtrando hojas de cálculo con los "
+"datos, o podría requerir consultas en la herramienta de almacenamiento de "
+"datos que ha elegido usar."
+
+#: ../../docs/guidance/using.md:1
+msgid "Worked example"
+msgstr "Ejemplo práctico"
+
+#: ../../None:1
+msgid ""
+"Using the UK Contracts Finder dataset in OCDS format, and [OCDS "
+"Kingfisher](https://github.com/open-contracting/kingfisher/), we can use the"
+" following query to fetch contracting processes classified under the "
+"['Architectural, construction, engineering and inspection "
+"services'](http://cpv.data.ac.uk/code-71000000.html) hierarchy of the EU "
+"Common Procurement Vocabulary."
+msgstr ""
+"Usando el conjunto de datos en formato OCDS de UK Contracts Finder y [OCDS "
+"Kingfisher](https://github.com/open-contracting/kingfisher/), podemos usar "
+"la siguiente consulta para obtener procesos de contratación clasificados "
+"bajo la jerarquía ['Servicios de arquitectura, construcción, ingeniería e "
+"inspección'](http://cpv.data.ac.uk/code-71000000.html) del Vocabulario Común"
+" de Adquisiciones de la UE (CPV, por sus siglas en inglés)."
+
+#: ../../None:32
+msgid ""
+"This returns over 11,000 procurement processes related to infrastructure, "
+"covering frameworks and procurements, with a value of up to £25bn a year. "
+"These processes include design work, construction and monitoring, and each "
+"needs to be reviewed to identify if it should be subject to monitoring."
+msgstr ""
+"Esto retorna más de 11.000 procesos de adquisición relacionados a "
+"infraestructura, cubriendo convenios marco y adquisiciones, con un valor de"
+"  £25.000 millones al año. Estos procesos incluyen trabajos de diseño, "
+"construcción y supervisión, y cada uno necesita ser revisado para "
+"identificar si debería estar sujeto a monitoreo."
+
+#: ../../docs/guidance/using.md:121
+msgid "(4) Populate project-level data"
+msgstr "(4) Llenar datos a nivel de proyecto"
+
+#: ../../docs/guidance/using.md:123
+msgid ""
+"If your analysis of OCDS data reveals infrastructure projects to monitor, "
+"you can:"
+msgstr ""
+"Si su análisis de datos OCDS revela proyectos de infraestructura para "
+"monitorear, puede:"
+
+#: ../../docs/guidance/using.md:125
+msgid ""
+"Use the information from a contracting process data to start populating a "
+"**project-level disclosure**;"
+msgstr ""
+"Usar la información de un proceso de contratación para empezar a llenar la "
+"**información a nivel de proyecto**;"
+
+#: ../../docs/guidance/using.md:127
+msgid ""
+"Search for **related contracts** in order to link any other design, "
+"construction or monitoring contracts to this project;"
+msgstr ""
+"Buscar **contratos relacionados** para enlazar cualquier otro contrato de "
+"diseño, construcción o supervisión a este proyecto;"
+
+#: ../../None:1
+msgid ""
+"When searching for related contracts, you may be looking for contracts from "
+"the same buyer, mentioning similar words or localities."
+msgstr ""
+"Cuando busque contratos relacionados, podría enfocarse en contratos con el "
+"mismo comprador, mencionando palabras o ubicaciones similares."
+
+#: ../../docs/guidance/using.md:139
+msgid ""
+"You may not be able to fill all the project-level details from the "
+"contracts, and may need to undertake additional research to find:"
+msgstr ""
+"Es posible que no pueda llenar todos los detalles a nivel de proyecto desde "
+"los datos de contratos, y pueda necesitar investigaciones adicionales para "
+"encontrar:"
+
+#: ../../docs/guidance/using.md:141
+msgid "The project owner and name"
+msgstr "El nombre del dueño del proyecto"
+
+#: ../../docs/guidance/using.md:142
+msgid "The full scope of the project"
+msgstr "El alcance completo del proyecto"
+
+#: ../../docs/guidance/using.md:143
+msgid "The total project budget and cost estimates"
+msgstr "El presupuesto total del proyecto y costos estimativos"
+
+#: ../../docs/guidance/using.md:144
+msgid ""
+"Any environmental impact or land and settlement impact studies that have "
+"been undertaken"
+msgstr ""
+"Cualquier estudio de impacto ambiental o a tierras y reasentamientos que se "
+"ha realizado"
+
+#: ../../None:1
+msgid ""
+"You can use a [blank example OC4IDS JSON file](../../_static/blank.json) to "
+"get started."
+msgstr ""
+"Puede usar un [archivo de ejemplo OC4IDS JSON en "
+"blanco](../../_static/blank.json) para empezar."
+
+#: ../../docs/guidance/using.md:156
+msgid "(5) Monitoring contracting process updates"
+msgstr "(5) Monitorear actualizaciones a procesos de contratación"
+
+#: ../../docs/guidance/using.md:158
+msgid ""
+"When a publisher is using OCDS correctly, and is providing updates on a "
+"contracting process under the same `ocid`, you should be able to regularly "
+"fetch the latest data for each contracting process you are monitoring, and "
+"to compare it with the existing data you have, looking for changes."
+msgstr ""
+"Cuando un publicador está usando OCDS de forma correcta, y provee "
+"actualizaciones a un proceso de contratación bajo el mismo `ocid`, usted "
+"debería poder obtener regularmente los datos actualizados para cada proceso "
+"de contratación que está monitoreado, y compararlos con los datos que ya "
+"posee, para identificar cambios."
+
+#: ../../docs/guidance/using.md:160
+msgid ""
+"Keep a copy each time the data changes, and if you see modifications to:"
+msgstr ""
+"Mantenga una copia cada vez que los datos cambian, y si ve modificaciones a:"
+
+#: ../../docs/guidance/using.md:162
+msgid "Price"
+msgstr "Precio"
+
+#: ../../docs/guidance/using.md:163
+msgid "Duration"
+msgstr "Duración"
+
+#: ../../docs/guidance/using.md:164
+msgid "Scope"
+msgstr "Alcance"
+
+#: ../../docs/guidance/using.md:166
+msgid "check whether an adequate explanation has been given for these."
+msgstr "verifique si se ha dado una explicación adecuada para estos."
+
+#: ../../docs/guidance/using.md:168
+msgid ""
+"You can use OC4IDS to record each time a change is detected, and the reasons"
+" that are given for the change."
+msgstr ""
+"Puede usar OC4IDS para registrar cada vez que se detecta un cambio, y las "
+"razones dadas para el cambio."
+
+#: ../../docs/guidance/using.md:170
+msgid "(6) Add project completion data"
+msgstr "(6) Añadir datos de finalización del proyecto"
+
+#: ../../docs/guidance/using.md:172
+msgid ""
+"When there is evidence that a project has reached completion, it is "
+"important to further update the **project-level disclosure**."
+msgstr ""
+"Cuando hay evidencia de que un proyecto ha llegado a su finalización, es "
+"importante actualizar la **información a nivel de proyecto**."
+
+#: ../../docs/guidance/using.md:174
+msgid ""
+"If the OCDS data includes implementation data, including transactions or "
+"final spending information, then it may be possible to compare the total sum"
+" of all contract spending against the original anticipated contract spend, "
+"and overall project budget. It may also be possible to compare final "
+"contract delivery dates with originally planned dates. This can be used to "
+"identify possible modifications that are in need to explanation."
+msgstr ""
+"Si los datos OCDS incluyen datos de implementación, incluyendo transacciones"
+" o información de gasto final, entonces sería posible comparar la suma total"
+" de todos los gastos en contratos con el gasto en contratos anticipado "
+"originalmente, y el presupuesto total del proyecto. También podría ser "
+"posible comparar las fechas finales de entrega de contratos con las fechas "
+"planeadas originalmente. Esto puede ser usado para identificar posibles "
+"modificaciones que necesitan explicación."
+
+#: ../../docs/guidance/using.md:176
+msgid ""
+"In other cases, you may need to identify other data sources (such as "
+"treasury or public spending data) that you can draw upon to check whether a "
+"project spend was as anticipated or not."
+msgstr ""
+"En otros casos, podría necesitar identificar otras fuentes de datos (como "
+"datos del Tesoro o de gastos públicos) a las que pueda recurrir para "
+"verificar si un gasto de proyecto se dio como estaba anticipado o no."
+
+#: ../../docs/guidance/using.md:178
+msgid "Tools and platform"
+msgstr "Herramientas y plataformas"
+
+#: ../../docs/guidance/using.md:180
+msgid ""
+"You can use OCDS data as part of a manual monitoring process, or you can "
+"integrate OCDS into a comprehensive transparency portal."
+msgstr ""
+"Puede usar datos OCDS como parte de un proceso manual de monitoreo, o puede "
+"integrar OCDS en un portal de transparencia integral."
+
+#: ../../docs/guidance/using.md:182
+msgid "Tools to help you with manual monitoring include:"
+msgstr ""
+"Las herramientas que pueden ayudarle con el monitoreo manual incluyen:"
+
+#: ../../docs/guidance/using.md:184
+msgid ""
+"[OCDS Kingfisher](https://github.com/open-contracting/kingfisher/) - a "
+"framework for regularly fetching, storing and querying OCDS data."
+msgstr ""
+"[OCDS Kingfisher](https://github.com/open-contracting/kingfisher/) - un "
+"marco de trabajo para extraer regularmente, almacenar y consultar datos "
+"OCDS."
+
+#: ../../docs/guidance/using.md:185
+msgid ""
+"[OCDS Merge](https://github.com/open-contracting/ocds-merge) - a library to "
+"combine multiple releases of OCDS data into a summary (compiledRelease), and"
+" to identify changes over time (versionedRelease)."
+msgstr ""
+"[OCDS Merge](https://github.com/open-contracting/ocds-merge) - una librería "
+"para combinar múltiples releases de OCDS en un resumen (compiledRelease), y "
+"para identificar cambios en el tiempo (versionedRelease)."
+
+#: ../../docs/guidance/using.md:186
+msgid ""
+"[OCDS Show](https://github.com/open-contracting/ocds-show) - a flexible "
+"framework for presenting templated views of OCDS data. Given a merged OCDS "
+"record, OCDS Show can highlight change over time."
+msgstr ""
+"[OCDS Show](https://github.com/open-contracting/ocds-show) - un marco de "
+"trabajo flexible para presentar datos OCDS en vistas predefinidas. Dado un "
+"récord OCDS mezclado, OCDS Show puede resaltar los cambios en el tiempo."
+
+#: ../../docs/guidance/using.md:188
+msgid ""
+"When building an integrated tool that integrates OCDS data into "
+"infrastructure project monitoring:"
+msgstr ""
+"Para construir una herramienta integral que incluya datos OCDS en el "
+"monitoreo de proyectos de infraestructura:"
+
+#: ../../docs/guidance/using.md:190
+msgid ""
+"The [OC4IDS](../../projects/index) provides a common data structure for "
+"recording project-level information;"
+msgstr ""
+"[OC4IDS](../../projects/index) provee una estructura de datos común para "
+"registrar información a nivel de proyecto;"
+
+#: ../../docs/guidance/using.md:192
+msgid ""
+"The [CoST IDS and OCDS Mapping](../../cost/index) provides guidance on how "
+"to use OCDS data to populate project-level and contracting process summary "
+"data."
+msgstr ""
+"El [mapeo CoST IDS y OCDS](../../cost/index) provee una guía sobre cómo usar"
+" datos OCDS para llenar datos a nivel de proyecto y de resumen de procesos "
+"de contratación."

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -1,0 +1,117 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/index.md:1
+msgid "Open Contracting for Infrastructure Data Standards Toolkit"
+msgstr ""
+"Manual de Contrataciones Abiertas para el Estándar de Datos sobre "
+"Infraestructura"
+
+#: ../../docs/index.md:3
+msgid ""
+"The Open Contracting Data Standard (OCDS) is already used to describe "
+"millions of procurement processes around the world relating to goods, "
+"services and public works. The CoST Infrastructure Data Standard (CoST IDS) "
+"has been used to guide what data and information should be disclosed at each"
+" stage of the project cycle on over 25,000 infrastructure projects."
+msgstr ""
+"El Estándar de Datos de Contrataciones Abiertas (OCDS, por sus siglas en "
+"inglés) es usado actualmente para describir millones de procesos de "
+"contratación alrededor del mundo relacionados a bienes, servicios y obras "
+"públicas. El Estándar de Datos sobre Infraestructura CoST (CoST IDS, por sus"
+" siglas en inglés) ha sido usado para establecer qué datos e información "
+"deberían ser divulgados en cada etapa del ciclo de un proyecto para más de "
+"25.000 proyectos de infraestructura."
+
+#: ../../docs/index.md:5
+msgid ""
+"This site describes how to combine **contract level disclosures using OCDS**"
+" with **project-level disclosure based on the CoST IDS**, in order to "
+"support scalable disclosure and monitoring of infrastructure project "
+"identification, preparation, implementation and delivery."
+msgstr ""
+"Este sitio describe cómo combinar la **divulgación de datos a nivel de "
+"contrataciones usando OCDS** con la **divulgación de datos a nivel de "
+"proyecto en base al IDS de CoST**, con el fin de apoyar la divulgación y el "
+"monitoreo escalables sobre la identificación, preparación, implementación y "
+"entrega de proyectos de infraestructura."
+
+#: ../../docs/index.md:7
+msgid ""
+"Trillions of dollars are spent every year on infrastructure and estimates "
+"suggest between 10 and 30% of infrastructure investment is lost through "
+"inefficiency, mismanagement and corruption. Access to better and more joined"
+" up data is essential to drive better quality, more affordable and more "
+"accessible infrastructure for government, citizens and business."
+msgstr ""
+"Billones de dólares son gastados cada año en infraestructura, y estimaciones"
+" sugieren que entre el 10 y 30% de inversiones en infraestructura se pierden"
+" debido a ineficiencias, malas gestiones y corrupción. El acceso a datos "
+"mejores y más consolidados es esencial para impulsar infraestructuras de "
+"mejor calidad, menos costosas y más accesibles para el gobierno, los "
+"ciudadanos y las empresas."
+
+#: ../../docs/index.md:9
+msgid ""
+"This Open Contracting for Infrastructure Data Standards (OC4IDS) Toolkit "
+"will show you how to:"
+msgstr ""
+"Este Manual de Contrataciones Abiertas para el Estándar de Datos sobre "
+"Infraestructura (OC4IDS) te mostrará cómo:"
+
+#: ../../docs/index.md:11
+msgid ""
+"[Publish standardized data](guidance/publishing) on infrastructure projects "
+"and contracts using the CoST IDS and OCDS."
+msgstr ""
+"[Publicar datos estandarizados](guidance/publishing) de proyectos de "
+"infraestructura y contratos usando CoST IDS y OCDS."
+
+#: ../../docs/index.md:13
+msgid ""
+"Extract [infrastructure contracting data from existing procurement "
+"portals](guidance/using)."
+msgstr ""
+"Extraer [datos de contrataciones en infraestructura desde portales de "
+"compras públicas existentes](guidance/using)."
+
+#: ../../docs/index.md:15
+msgid ""
+"Connect contract and project-level information [using "
+"OC4IDS](projects/index)."
+msgstr ""
+"Conectar información de contratos e información a nivel de proyecto [usando "
+"OC4IDS](projects/index)."
+
+#: ../../docs/index.md:17
+msgid "Assess published data [against the CoST IDS](guidance/evaluating)."
+msgstr "Evaluar datos publicados [contra CoST IDS](guidance/evaluating)."
+
+#: ../../docs/index.md:19
+msgid "Make use of data when monitoring infrastructure projects."
+msgstr "Usar datos al monitorear proyectos de infraestructura."
+
+#: ../../docs/index.md:21
+msgid "Contents"
+msgstr "Contenido"

--- a/locale/es/LC_MESSAGES/infrastructurecodelists.po
+++ b/locale/es/LC_MESSAGES/infrastructurecodelists.po
@@ -1,0 +1,2154 @@
+# Translations template for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# 
+# Translators:
+# Charlie Pinder <charlie.pinder@opendataservices.coop>, 2019
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-05-14 11:41+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: schema/project-level/codelists/contractNature.csv
+#: schema/project-level/codelists/contractingProcessStatus.csv
+#: schema/project-level/codelists/currency.csv
+#: schema/project-level/codelists/documentType.csv
+#: schema/project-level/codelists/geometryType.csv
+#: schema/project-level/codelists/locationGazetteers.csv
+#: schema/project-level/codelists/method.csv
+#: schema/project-level/codelists/modificationType.csv
+#: schema/project-level/codelists/partyRole.csv
+#: schema/project-level/codelists/projectSector.csv
+#: schema/project-level/codelists/projectStatus.csv
+#: schema/project-level/codelists/projectType.csv
+#: schema/project-level/codelists/relatedProject.csv
+#: schema/project-level/codelists/relatedProjectScheme.csv
+#: schema/project-level/codelists/releaseTag.csv
+msgid "Code"
+msgstr "Código"
+
+#: schema/project-level/codelists/contractNature.csv
+#: schema/project-level/codelists/contractingProcessStatus.csv
+#: schema/project-level/codelists/currency.csv
+#: schema/project-level/codelists/documentType.csv
+#: schema/project-level/codelists/geometryType.csv
+#: schema/project-level/codelists/locationGazetteers.csv
+#: schema/project-level/codelists/method.csv
+#: schema/project-level/codelists/modificationType.csv
+#: schema/project-level/codelists/partyRole.csv
+#: schema/project-level/codelists/projectSector.csv
+#: schema/project-level/codelists/projectStatus.csv
+#: schema/project-level/codelists/projectType.csv
+#: schema/project-level/codelists/relatedProject.csv
+#: schema/project-level/codelists/relatedProjectScheme.csv
+#: schema/project-level/codelists/releaseTag.csv
+msgid "Title"
+msgstr "Título"
+
+#: schema/project-level/codelists/contractNature.csv
+#: schema/project-level/codelists/contractingProcessStatus.csv
+#: schema/project-level/codelists/documentType.csv
+#: schema/project-level/codelists/geometryType.csv
+#: schema/project-level/codelists/locationGazetteers.csv
+#: schema/project-level/codelists/method.csv
+#: schema/project-level/codelists/modificationType.csv
+#: schema/project-level/codelists/partyRole.csv
+#: schema/project-level/codelists/projectSector.csv
+#: schema/project-level/codelists/projectStatus.csv
+#: schema/project-level/codelists/projectType.csv
+#: schema/project-level/codelists/relatedProject.csv
+#: schema/project-level/codelists/relatedProjectScheme.csv
+#: schema/project-level/codelists/releaseTag.csv
+msgid "Description"
+msgstr "Descripción"
+
+#. Title
+#: schema/project-level/codelists/contractNature.csv:1
+msgid "Design"
+msgstr "Diseño"
+
+#. Description
+#: schema/project-level/codelists/contractNature.csv:1
+msgid "This contracting process relates to design of the project."
+msgstr "Este proceso de contratación está relacionado al diseño del proyecto."
+
+#. Title
+#: schema/project-level/codelists/contractNature.csv:2
+#: schema/project-level/codelists/projectType.csv:1
+#: schema/project-level/codelists/relatedProject.csv:1
+msgid "Construction"
+msgstr "Construcción"
+
+#. Description
+#: schema/project-level/codelists/contractNature.csv:2
+msgid ""
+"This contracting process relates to build or construction work for the "
+"project."
+msgstr ""
+"Este proceso de contratación está relacionado a trabajos de construcción del"
+" proyecto."
+
+#. Title
+#: schema/project-level/codelists/contractNature.csv:3
+msgid "Supervision"
+msgstr "Supervisión"
+
+#. Description
+#: schema/project-level/codelists/contractNature.csv:3
+msgid ""
+"This contracting process relates to supervision or monitoring of the "
+"project."
+msgstr ""
+"Este proceso de contratación está relacionado a la supervisión o monitoreo "
+"de este proyecto."
+
+#: schema/project-level/codelists/contractingProcessStatus.csv
+msgid "Business Logic"
+msgstr "Lógica de negocio"
+
+#. Title
+#: schema/project-level/codelists/contractingProcessStatus.csv:1
+msgid "Pre-award"
+msgstr "Pre-adjudicación"
+
+#. Description
+#: schema/project-level/codelists/contractingProcessStatus.csv:1
+msgid "No contract has yet been awarded, and the process has not ended."
+msgstr "Ningún contrato ha sido adjudicado aún, y el proceso no ha terminado."
+
+#. Title
+#: schema/project-level/codelists/contractingProcessStatus.csv:2
+msgid "Active"
+msgstr "Activo"
+
+#. Description
+#: schema/project-level/codelists/contractingProcessStatus.csv:2
+msgid "A contract was awarded, but not all contracts have ended."
+msgstr ""
+"Un contrato fue adjudicado, pero no todos los contratos han terminado."
+
+#. Title
+#: schema/project-level/codelists/contractingProcessStatus.csv:3
+msgid "Closed"
+msgstr "Cerrado"
+
+#. Description
+#: schema/project-level/codelists/contractingProcessStatus.csv:3
+msgid ""
+"The process ended with no contract being awarded, or all contracts have "
+"ended."
+msgstr ""
+"El proceso terminó sin adjudicar ningún contrato, o todos los contratos han "
+"terminado."
+
+#: schema/project-level/codelists/currency.csv
+#: schema/project-level/codelists/geometryType.csv
+#: schema/project-level/codelists/locationGazetteers.csv
+#: schema/project-level/codelists/method.csv
+#: schema/project-level/codelists/releaseTag.csv
+msgid "Extension"
+msgstr "Extensión"
+
+#: schema/project-level/codelists/documentType.csv
+#: schema/project-level/codelists/partyRole.csv
+msgid "Source"
+msgstr "Fuente"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:1
+msgid "Value for money analysis"
+msgstr "Análisis de valor por dinero"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:1
+msgid ""
+"A summary of the value for money analysis carried out for the project, along"
+" with supporting figures, calculations and business case, based on projected"
+" or actual procurement outcomes."
+msgstr ""
+"Un resumen del análisis del valor por dinero llevado a cabo para el "
+"proyecto, junto con figuras de apoyo, cálculos y casos de negocio, basados "
+"en resultados de adquisiciones proyectadas o reales."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:2
+msgid "Technical Specifications"
+msgstr "Especificaciones Técnicas"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:2
+msgid "Detailed technical information about goods or services to be provided."
+msgstr "Información técnica detallada sobre los bienes o servicios a proveer."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:3
+msgid "Service descriptions"
+msgstr "Descripciones de servicios"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:3
+msgid "A high-level description of the services"
+msgstr "Una descripción de alto nivel de los servicios"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:4
+msgid "Estimated demand"
+msgstr "Demanda estimada"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:4
+msgid ""
+"A narrative describing the estimated demand to be served (annually) by the "
+"project."
+msgstr ""
+"Una narrativa que describe la demanda estimada a ser servida (anualmente) "
+"por el proyecto."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:5
+msgid "Contract draft"
+msgstr "Borrador de contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:5
+msgid "A draft or pro-forma copy of the contract."
+msgstr "Un borrador o copia pro-forma del contrato."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:6
+msgid "Signed Contract"
+msgstr "Contrato Firmado"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:6
+msgid ""
+"A copy of the signed contract. Consider providing both machine-readable "
+"(e.g. original PDF, Word or Open Document format files), and a separate "
+"document entry for scanned-signed pages where this is required."
+msgstr ""
+"Una copia del contrato firmado. Considere proveer tanto un documento legible"
+" por computadora (p.ej. PDF original, o formato de Word u Open Document) "
+"como un documento separado para páginas firmadas digitalizadas donde sea "
+"requerido."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:7
+msgid "Feasibility study"
+msgstr "Estudio de factibilidad"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:7
+msgid ""
+"Documentation of feasibility studies carried out for this contracting "
+"process, providing information on net benefits or costs of the proposed "
+"goods, works or services."
+msgstr ""
+"Documentación de la evaluación de factibilidad llevada a cabo para este "
+"proceso de contratación, proveyendo información sobre los beneficios o "
+"costos netos de los bienes, obras o servicios propuestos."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:8
+msgid "Environmental Impact"
+msgstr "Impacto Ambiental"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:8
+msgid ""
+"Documentation of assessments of the environmental impacts (e.g. impacts on "
+"flora, fauna & woodlands, areas of natural beauty, carbon emissions etc.) "
+"and mitigation measures (e.g. pollution control, low carbon solutions, "
+"sustainable timber etc.) for this contracting process or project."
+msgstr ""
+"Documentación de las evaluaciones de impacto ambiental (ej. impacto en "
+"flora, fauna y bosques, áreas naturales, emisiones de carbono, etc.) y "
+"medidas de mitigación (ej. control de contaminación, soluciones bajas en "
+"carbono, madera sustentable, etc.) para este proceso de contratación o "
+"proyecto."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:9
+msgid "Final Audit"
+msgstr "Auditoría Final"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:9
+msgid ""
+"Documentation of a final audit carried out at the end of contract "
+"implementation."
+msgstr ""
+"Documentación de una auditoría final llevada a cabo al final de la "
+"implementación de un contrato."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:10
+msgid "Tender Notice"
+msgstr "Aviso de Licitación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:10
+msgid ""
+"The formal notice that gives details of a tender. This may be a link to a "
+"downloadable document, to a web page, or to an official gazette in which the"
+" notice is contained."
+msgstr ""
+"El aviso formal que da los detalles de una licitación. Este puede ser un "
+"enlace a un documento descargable, a un sitio web o a una gaceta oficial en "
+"la cual se contiene el aviso. "
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:11
+msgid "Evaluation Committee Details"
+msgstr "Detalles de comité de evaluación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:11
+msgid "Information on the constitution of the evaluation committee"
+msgstr "Información de la constitución del comité de evaluación"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:12
+msgid "Request for Qualification"
+msgstr "Pedido de Calificación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:12
+msgid ""
+"The set of documents issued by the procuring authority that constitute the "
+"basis of the qualification and potentially the pre-selection of candidates "
+"(the short list). Qualified (or short-listed candidates) will then be "
+"invited to submit a proposal (or to enter into a new phase prior to bid "
+"submission, such as a dialogue phase or interactive phase)."
+msgstr ""
+"El conjunto de documentos emitidos por la entidad compradora que constituye "
+"la base de la calificación y potencialmente la pre-selección de candidatos. "
+"Los candidatos calificados serán invitados luego a enviar una propuesta (o a"
+" entrar a una nueva fase previa a la presentación de ofertas, tales como una"
+" fase de diálogo o una fase interactiva)."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:13
+msgid "Evaluation Criteria"
+msgstr "Criterios de Evaluación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:13
+msgid "Documentation on how bids will be evaluated."
+msgstr "Documentación sobre cómo se evaluarán las ofertas."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:14
+msgid "Minutes"
+msgstr "Minutas"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:14
+msgid "Minutes of pre-bid meetings, or other relevant meetings."
+msgstr ""
+"Minutas de reuniones previas a las ofertas, u otras reuniones relevantes."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:15
+msgid "Shortlisted Firms"
+msgstr "Firmas Preseleccionadas"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:15
+msgid ""
+"Documentation providing information on shortlisted firms. Structured "
+"versions of this information can be provided using the bids extension."
+msgstr ""
+"Documentación que provee información sobre las firmas preseleccionadas. Se "
+"pueden proveer versiones estructuradas de esta información usando la "
+"extensión de ofertas."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:16
+msgid "Negotiation Parameters"
+msgstr "Parámetros de negociación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:16
+msgid ""
+"A description of the parameters for negotiation with the preferred proponent"
+msgstr ""
+"Una descripción de los parámetros para la negociación con el proponente "
+"preferido."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:17
+msgid "Evaluation report"
+msgstr "Reporte de evaluación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:17
+msgid ""
+"Documentation on the evaluation of the bids and the application of the "
+"evaluation criteria, including the justification for the award"
+msgstr ""
+"Documentación sobre la evaluación de las ofertas y la aplicación de los "
+"criterios de evaluación, incluyendo la justificación para la adjudicación"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:18
+msgid "Guarantees"
+msgstr "Garantías"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:18
+msgid ""
+"Documentation of guarantees relating to a contracting process or contract."
+msgstr ""
+"Documentación de garantías relacionadas con el proceso de contratación o el "
+"contrato."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:19
+msgid "Defaults"
+msgstr "Faltas"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:19
+msgid "Information on events of default"
+msgstr "Información de los eventos relacionados con faltas"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:20
+msgid "Termination"
+msgstr "Terminación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:20
+msgid "Information on contract termination"
+msgstr "Información sobre terminación del contrato"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:21
+msgid "Performance report"
+msgstr "Reporte (informe) de desempeño"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:21
+msgid "Performance assessment reports"
+msgstr "Reportes (informes) de evaluación de desempeño"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:22
+msgid "Notice of planned procurement"
+msgstr "Aviso de adquisición planeada"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:22
+msgid ""
+"A notice published by the procuring entity regarding their plans for future "
+"procurement, also known as a prior information notice. The procuring entity "
+"can use the notice of planned procurement as a tender notice."
+msgstr ""
+"Un aviso publicado por la entidad de adquisición acerca de sus planes para "
+"una futura compra, también conocida como aviso de información previa. La "
+"entidad de adquisición puede usar el aviso de adquisición planeada como un "
+"aviso de licitación."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:23
+msgid "Award notice"
+msgstr "Aviso de adjudicación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:23
+msgid ""
+"The formal notice that gives details of the contract award. This can be a "
+"link to a downloadable document, to a web page, or to an official gazette in"
+" which the notice is contained."
+msgstr ""
+"El aviso formal que da detalles de la adjudicación del contrato. Esto puede "
+"ser un enlace a un documento descargable, una página web, o a una gaceta "
+"oficial en la que el aviso está contenido."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:24
+msgid "Contract notice"
+msgstr "Aviso de contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:24
+msgid ""
+"The formal notice that gives details of a contract being signed and valid to"
+" start implementation. This can be a link to a downloadable document, to a "
+"web page, or to an official gazette in which the notice is contained."
+msgstr ""
+"El aviso formal que provee detalles de un contrato siendo firmado y válido "
+"para empezar la implementación. Este puede ser un enlace a un documento "
+"descargable, una página web o a una gaceta oficial en la que el aviso está "
+"contenido."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:25
+msgid "Completion certificate"
+msgstr "Certificado de finalización"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:25
+msgid ""
+"A completion certificate issued by a relevant authority providing evidence "
+"that works were completed to a certain level of quality. Completion "
+"certificates might only be relevant for particular kinds of contracting "
+"processes."
+msgstr ""
+"Un certificado de finalización expedido por la autoridad relevante que "
+"provee evidencia de que las obras fueron finalizadas hasta un cierto nivel "
+"de calidad. Los certificados de finalización podrían ser relevantes sólo "
+"para tipos particulares de procesos de contratación."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:26
+msgid "Procurement plan"
+msgstr "Plan de adquisiciones"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:26
+msgid ""
+"Documentation that sets out the basis for this particular contracting "
+"process."
+msgstr ""
+"Documentación que establece las bases para este proceso de contratación en "
+"particular."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:27
+msgid "Bidding documents"
+msgstr "Documentos de oferta"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:27
+msgid ""
+"Documentation for potential suppliers, describing the goals of the contract "
+"(e.g. goods and services to be procured), and the bidding process."
+msgstr ""
+"Documentación para proveedores potenciales, describiendo las metas del "
+"contrato (p.ej. bienes y servicios a contratar) y el proceso de envío de "
+"propuestas."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:28
+msgid "Arrangements for ending contract"
+msgstr "Arreglos para finalizar un contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:28
+msgid "Documentation of the arrangements for ending the contract(s)."
+msgstr "Documentación de los arreglos para terminar el contrato(s)."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:29
+msgid "Contract schedules"
+msgstr "Calendario del contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:29
+msgid ""
+"Any document which contains additional terms, obligations or information "
+"related to the contract, such as a schedule, appendix, annex, attachment or "
+"addendum."
+msgstr ""
+"Cualquier documento que contenga términos adicionales, obligaciones o "
+"información relacionada con el contrato, tal como un calendario, apéndice, "
+"anexo, adenda o adición."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:30
+msgid "Physical progress reports"
+msgstr "Reportes de progreso físico"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:30
+msgid ""
+"Documentation on the status of implementation, usually against key "
+"milestones."
+msgstr ""
+"Documentación sobre el estado de la implementación, usualmente comparado con"
+" hitos clave."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:31
+msgid "Financial progress reports"
+msgstr "Reportes de progreso financiero"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:31
+msgid ""
+"Documentation providing dates and amounts of stage payments made (against "
+"total amount) and the source of those payments, including cost overruns, if "
+"any. Structured versions of this information can be provided through "
+"contract implementation transactions."
+msgstr ""
+"Documentación que provee fechas y montos de pagos realizados (contra el "
+"monto total) y el origen de esos pagos, incluyendo excesos de costos, si los"
+" hay. Se pueden proveer versiones estructuradas de esta información a través"
+" de las transacciones de implementación del contrato. "
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:32
+msgid "Public hearing notice"
+msgstr "Aviso de audiencia pública"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:32
+msgid ""
+"Documentation of any public hearings that took place as part of the planning"
+" for this contracting process."
+msgstr ""
+"Documentación de cualquier audiencia que ocurrió como parte de la planeación"
+" de este proceso de contratación."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:33
+msgid "Market studies"
+msgstr "Estudios de mercado"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:33
+msgid ""
+"Documentation of any market studies that took place as part of the planning "
+"for this contracting process."
+msgstr ""
+"Documentación de cualquier estudio de mercado que haya ocurrido como parte "
+"de la planeación de este proceso de contrato."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:34
+msgid "Eligibility criteria"
+msgstr "Criterios de elegibilidad"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:34
+msgid "Detailed documents about the eligibility of bidders."
+msgstr "Documentos detallados sobre la elegibilidad de los licitantes."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:35
+msgid "Clarifications to bidders questions"
+msgstr "Aclaraciones a las preguntas de los licitantes"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:35
+msgid ""
+"Documentation that provides replies to issues raised in pre-bid conferences "
+"or an enquiry processes."
+msgstr ""
+"Documentación que provee las respuestas a las cuestiones apuntadas en "
+"reuniones pre-ofertas o procesos de preguntas."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:36
+msgid "Assessment of government's assets and liabilities"
+msgstr "Evaluación de los activos y responsabilidades del gobierno"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:36
+msgid ""
+"Documentation covering assessments of the government's assets and "
+"liabilities related to this contracting process."
+msgstr ""
+"Documentación que cubre las evaluaciones de los activos y responsabilidades "
+"del gobierno relacionados con este proceso de contratación."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:37
+msgid "Provisions for management of risks and liabilities"
+msgstr "Cláusulas para el manejo de riesgos y responsabilidades"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:37
+msgid ""
+"Documentation covering how risks will be managed as part of this contracting"
+" process."
+msgstr ""
+"Documentación que cubre cómo se manejarán los riesgos como parte de este "
+"proceso de contratación."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:38
+msgid "Winning bid"
+msgstr "Oferta ganadora"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:38
+msgid ""
+"Documentation of the winning bid, including, wherever applicable, a full "
+"copy of the proposal received."
+msgstr ""
+"Documentación de la oferta ganadora, incluyendo, cuando aplique, una copia "
+"completa de la oferta recibida."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:39
+msgid "Complaints and decisions"
+msgstr "Quejas y decisiones"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:39
+msgid ""
+"Documentation of any complaints received, or decisions in response to "
+"complaints."
+msgstr ""
+"Documentación de cualquier queja recibida o decisiones en respuesta a dichas"
+" quejas."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:40
+msgid "Annexes to the contract"
+msgstr "Anexos al contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:40
+msgid ""
+"Copies of annexes and other supporting documentation related to the "
+"contract."
+msgstr ""
+"Copias de anexos y otra documentación de soporte relacionados con el "
+"contrato."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:41
+msgid "Subcontracts"
+msgstr "Subcontratos"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:41
+msgid ""
+"Documentation detailing subcontracts and/or providing a copy of subcontracts"
+" themselves. Where OCDS data on the subcontracts exists, this can be "
+"declared using the relatedProcess block."
+msgstr ""
+"Documentación que detalla los subcontratos y/o provee una copia de los "
+"subcontratos. Donde haya datos de OCDS sobre los subcontratos, puede "
+"declararse usando el bloque de relatedProcess."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:42
+msgid "Needs assessment"
+msgstr "Evaluación de necesidades"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:42
+msgid ""
+"Documentation of the needs assessments carried out for this contracting "
+"process or project addressing demand for the project or investment from the "
+"affected communities or users."
+msgstr ""
+"Documentación de la evaluación de necesidades llevada a cabo para este "
+"proceso de contratación o proyecto, aborda la demanda para el proyecto o "
+"inversión para las comunidades afectadas o usuarios."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:43
+msgid "Project plan"
+msgstr "Plan de proyecto"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:43
+msgid ""
+"Documentation of project planning for this contracting process, and, where "
+"applicable, a copy of the project plan document."
+msgstr ""
+"Documentación de la planeación de proyecto para este proceso de contratación"
+" y, donde aplique, una copia del documento del plan de proyecto"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:44
+msgid "Bill of quantity"
+msgstr "Estimación cuantitativa"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:44
+msgid ""
+"Documentation that provides itemized information on materials, parts and "
+"labour, and the terms and conditions for their provision, providing "
+"information that would enable bidders to price work effectively. Structured "
+"versions of item and quantity information at each of tender, award and "
+"contract stage can be provided using units within the items building block."
+msgstr ""
+"Documentación que provee la información desglosada de materiales, partes y "
+"mano de obra y los términos y condiciones para su provisión, dando "
+"información que permitirá a los licitadores dar efectivamente un precio. Se "
+"pueden proveer versiones estructuradas de artículos y cantidades en la etapa"
+" de licitación, adjudicación y contrato usando las unidades dentro del "
+"bloque de artículos."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:45
+msgid "Information on bidders"
+msgstr "Información de Licitante"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:45
+msgid ""
+"Documentation on bidders or participants, their validation documents and any"
+" procedural exemptions for which they qualify."
+msgstr ""
+"Documentación sobre los oferentes o participantes, sus documentos de "
+"validación y cualquier excepción de procedimientos para el cual califiquen."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:46
+msgid "Conflict of interest"
+msgstr "Conflicto de interés"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:46
+msgid "Documentation of conflicts of interest declared or uncovered."
+msgstr "Documentación de conflictos de interés declarados o descubiertos."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:47
+msgid "Debarments"
+msgstr "Inhabilitaciones"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:47
+msgid "Documentation of any debarments issued."
+msgstr "Documentación de cualquier inhabilitación efectuada."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:48
+msgid "Illustrations"
+msgstr "Ilustraciones"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:48
+msgid ""
+"Images intended to provide supporting information. The URL for images should"
+" be directly to an image file that applications can display as part of a "
+"gallery of images. At the tender stage, images can be illustrations of "
+"goods, works or services needed or for sale. At the implementation stage, "
+"images can be illustrations or visual evidence of physical progress."
+msgstr ""
+"Imágenes destinadas a proveer información de soporte. La URL para imágenes "
+"debería estar dirigida directamente a un archivo de imagen que las "
+"aplicaciones puedan desplegar como parte de una galería de imágenes. En la "
+"fase de licitación, las imágenes pueden ser ilustraciones de bienes, "
+"trabajos o servicios requeridos o a la venta. En la fase de implementación, "
+"las imágenes pueden ser ilustraciones o evidencia visual de progreso físico."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:49
+msgid "Bid submission documents"
+msgstr "Documentos de presentación de oferta"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:49
+msgid "Documentation submitted by a bidder as part of their proposal."
+msgstr "Documentación enviada por un licitante como parte de su oferta"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:50
+msgid "Contract summary"
+msgstr "Resumen del contrato"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:50
+msgid ""
+"Documentation providing an overview of the key terms and sections of the "
+"contract. Commonly used for large and complex contracts."
+msgstr ""
+"Documentación que da una imagen general de los términos y secciones clave "
+"del contrato. Comúnmente usado para contratos largos y complejos."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:51
+msgid "Cancellation details"
+msgstr "Detalles de cancelación"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:51
+msgid ""
+"Documentation of the arrangements, or reasons, for cancellation of a "
+"contracting process, award or specific contract."
+msgstr ""
+"Documentación de los acuerdos, o razones, para la cancelación de un proceso "
+"de contratación, adjudicación o contrato específico."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:52
+msgid "Project scope"
+msgstr "Alcance del proyecto"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:52
+msgid ""
+"A description of the main outputs from the project that are being taken "
+"forward into construction (including type, quantity and units)"
+msgstr ""
+"Una descripción de los principales resultados del proyecto que serán "
+"llevados a construcción (incluyendo tipo, cantidad y unidades)"
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:53
+msgid "Land and Settlement Impact"
+msgstr "Impacto en tierras y reasentamientos"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:53
+msgid ""
+"State the amount of land and property that was acquired for the project "
+"(e.g. 25sq km land), and outline related impacts (e.g. archaeological issues"
+" (moved Saxon burial site), local/indigenous settlements (relocated 5 "
+"indigenous villages of 500 villagers each), impacts on local businesses e.g."
+" (30 business properties purchased))."
+msgstr ""
+"Indica la cantidad de tierras y propiedades que fueron adquiridas para el "
+"proyecto (ej. 25km² de tierras), y resume los impactos relacionados (ej. "
+"problemas arqueológicos (se relocalizó un cementerio sajón), asentamientos "
+"locales/indígenas (se relocalizaron 5 aldeas indígenas de 500 habitantes "
+"cada una), impactos en negocios locales (ej. se compraron 30 propiedades "
+"comerciales))."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:54
+msgid "Project evaluation"
+msgstr "Evaluación del proyecto"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:54
+msgid ""
+"Generally published at the conclusion of a project, providing a technical "
+"and financial summary of delivery."
+msgstr ""
+"Generalmente publicado al terminar un proyecto, provee un resumen técnico y "
+"financiero de la entrega."
+
+#. Title
+#: schema/project-level/codelists/documentType.csv:55
+msgid "Budget approval"
+msgstr "Aprobación del presupuesto"
+
+#. Description
+#: schema/project-level/codelists/documentType.csv:55
+msgid "Additional details about the approval of the budget."
+msgstr "Detalles adicionales sobre la aprobación del presupuesto."
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:1
+msgid "Point"
+msgstr "Punto"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:1
+msgid "For type 'Point', the 'coordinates' member is a single position."
+msgstr "Para el tipo 'Point', el miembro 'coordinates' es una sola posición."
+
+#. Extension
+#: schema/project-level/codelists/geometryType.csv:1
+#: schema/project-level/codelists/geometryType.csv:2
+#: schema/project-level/codelists/geometryType.csv:3
+#: schema/project-level/codelists/geometryType.csv:4
+#: schema/project-level/codelists/geometryType.csv:5
+#: schema/project-level/codelists/geometryType.csv:6
+#: schema/project-level/codelists/locationGazetteers.csv:1
+#: schema/project-level/codelists/locationGazetteers.csv:2
+#: schema/project-level/codelists/locationGazetteers.csv:3
+#: schema/project-level/codelists/locationGazetteers.csv:4
+#: schema/project-level/codelists/locationGazetteers.csv:5
+#: schema/project-level/codelists/locationGazetteers.csv:6
+msgid "Location"
+msgstr "Ubicación"
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:2
+msgid "MultiPoint"
+msgstr "Multipunto"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:2
+msgid ""
+"For type 'MultiPoint', the 'coordinates' member is an array of positions."
+msgstr ""
+"Para el tipo 'MultiPoint', el miembro 'coordinates' es una lista de "
+"posiciones."
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:3
+msgid "LineString"
+msgstr "Línea"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:3
+msgid ""
+"For type 'LineString', the 'coordinates' member is an array of two or more "
+"positions."
+msgstr ""
+"Para el tipo 'LineString', el miembro 'coordinates' es una lista de una o "
+"más posiciones."
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:4
+msgid "MultiLineString"
+msgstr "Multilínea"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:4
+msgid ""
+"For type 'MultiLineString', the 'coordinates' member is an array of "
+"LineString coordinate arrays."
+msgstr ""
+"Para el tipo 'MultiLineString', el miembro 'coordinates' es una lista de "
+"listas de coordenadas tipo LineString."
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:5
+msgid "Polygon"
+msgstr "Polígono"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:5
+msgid ""
+"For type 'Polygon', the 'coordinates' member MUST be an array of linear ring"
+" coordinate arrays."
+msgstr ""
+"Para el tipo 'Polygon', el miembro 'coordinates' DEBE ser una lista de "
+"listas de coordenadas tipo linear ring."
+
+#. Title
+#: schema/project-level/codelists/geometryType.csv:6
+msgid "MultiPolygon"
+msgstr "Multipolígono"
+
+#. Description
+#: schema/project-level/codelists/geometryType.csv:6
+msgid ""
+"For type 'MultiPolygon', the 'coordinates' member is an array of Polygon "
+"coordinate arrays."
+msgstr ""
+"Para el tipo 'MultiPolygon', el miembro 'coordinates' es una lista de listas"
+" de coordenadas tipo Polygon."
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:1
+msgid "EU Nomenclature of Territorial Units for Statistics"
+msgstr "Nomenclatura de Unidades Territoriales para Estadísticas de la UE"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:1
+msgid ""
+"The Nomenclature of Territorial Units for Statistics (NUTS) was established "
+"by Eurostat in order to provide a single uniform breakdown of territorial "
+"units for the production of regional statistics for the European Union."
+msgstr ""
+"La Nomenclatura de Unidades Territoriales para Estadísticas (NUTS) fue "
+"establecida por Eurostat con el fin de proveer un desglose único y uniforme "
+"de unidades territoriales, para la producción de estadísticas regionales "
+"para la Unión Europea."
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:2
+msgid "ISO Country Codes (3166-1 alpha-2)"
+msgstr "Códigos de Países ISO (3166-1 alpha-2)"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:2
+msgid "ISO 2-Digit Country Codes"
+msgstr "Códigos de Países de 2 Dígitos ISO"
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:3
+msgid "GeoNames"
+msgstr "GeoNames"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:3
+msgid ""
+"GeoNames provides numerical identifiers for many points of interest around "
+"the world, including administrative divisions, populated centres and other "
+"locations, embedded within a structured tree of geographic relations."
+msgstr ""
+"GeoNames provee identificadores numéricos para muchos puntos de interés "
+"alrededor del mundo, incluyendo divisiones administrativas, centros poblados"
+" y otras localizaciones, embebidos dentro de un árbol estructurado de "
+"relaciones geográficas."
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:4
+msgid "OpenStreetMap Node"
+msgstr "Nodo de OpenStreetMap"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:4
+msgid ""
+"OpenStreetMap Nodes consist of a single point in space defined by a "
+"latitude, longitude and node ID. Nodes may have tags to indicate the "
+"particular geographic feature they represent."
+msgstr ""
+"Los nodos de OpenStreetMap consisten en un solo punto en el espacio definido"
+" por una latitud, longitud y ID de nodo. Los nodos pueden tener etiquetas "
+"para indicar la característica geográfica en particular que representan."
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:5
+msgid "OpenStreetMap Relation"
+msgstr "Relación de OpenStreetMap"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:5
+msgid ""
+"Relations are used to model logical (and usually local) or geographic "
+"relationships between objects. In practice, boundaries of geographic areas "
+"are available as Relations in OpenStreetMap."
+msgstr ""
+"Las relaciones son usadas para modelar relaciones lógicas (y usualmente "
+"locales) o geográficas entre objetos. En la práctica, los límites de áreas "
+"geográficas están disponibles como relaciones en OpenStreetMap."
+
+#. Title
+#: schema/project-level/codelists/locationGazetteers.csv:6
+msgid "OpenStreetMap Way"
+msgstr "Ruta de OpenStreetMap"
+
+#. Description
+#: schema/project-level/codelists/locationGazetteers.csv:6
+msgid ""
+"An OpenStreetMap Way is an ordered list of OpenStreetMap nodes. May be used "
+"to describe fragments of roads or local boundaries and bounding boxes."
+msgstr ""
+"Una ruta de OpenStreetMap es una lista ordenada de nodos de OpenStreetMap. "
+"Puede ser usado para describir fragmentos de carreteras o límites locales y "
+"puntos delimitadores."
+
+#. Title
+#: schema/project-level/codelists/method.csv:1
+msgid "Open"
+msgstr "Abierta"
+
+#. Description
+#: schema/project-level/codelists/method.csv:1
+msgid "All interested suppliers can submit a tender."
+msgstr "Todos los proveedores interesados pueden presentar una oferta."
+
+#. Extension
+#: schema/project-level/codelists/method.csv:1
+#: schema/project-level/codelists/method.csv:2
+#: schema/project-level/codelists/method.csv:3
+#: schema/project-level/codelists/method.csv:4
+#: schema/project-level/codelists/releaseTag.csv:1
+#: schema/project-level/codelists/releaseTag.csv:2
+#: schema/project-level/codelists/releaseTag.csv:3
+#: schema/project-level/codelists/releaseTag.csv:4
+#: schema/project-level/codelists/releaseTag.csv:5
+#: schema/project-level/codelists/releaseTag.csv:6
+#: schema/project-level/codelists/releaseTag.csv:7
+#: schema/project-level/codelists/releaseTag.csv:8
+#: schema/project-level/codelists/releaseTag.csv:9
+#: schema/project-level/codelists/releaseTag.csv:10
+#: schema/project-level/codelists/releaseTag.csv:11
+#: schema/project-level/codelists/releaseTag.csv:12
+#: schema/project-level/codelists/releaseTag.csv:13
+#: schema/project-level/codelists/releaseTag.csv:14
+#: schema/project-level/codelists/releaseTag.csv:15
+#: schema/project-level/codelists/releaseTag.csv:16
+msgid "OCDS Core"
+msgstr "OCDS Base"
+
+#. Title
+#: schema/project-level/codelists/method.csv:2
+msgid "Selective"
+msgstr "Selectiva"
+
+#. Description
+#: schema/project-level/codelists/method.csv:2
+msgid "Only qualified suppliers are invited to submit a tender."
+msgstr ""
+"Sólo los proveedores calificados son invitados a enviar una propuesta."
+
+#. Title
+#: schema/project-level/codelists/method.csv:3
+msgid "Limited"
+msgstr "Limitada"
+
+#. Description
+#: schema/project-level/codelists/method.csv:3
+msgid "The procuring entity contacts a number of suppliers of its choice."
+msgstr ""
+"La entidad licitadora contacta a un número de proveedores de su elección."
+
+#. Title
+#: schema/project-level/codelists/method.csv:4
+msgid "Direct"
+msgstr "Directa"
+
+#. Description
+#: schema/project-level/codelists/method.csv:4
+msgid "The contract is awarded to a single supplier without competition."
+msgstr "El contrato se otorga a un solo proveedor sin competencia."
+
+#. Title
+#: schema/project-level/codelists/modificationType.csv:1
+msgid "Duration"
+msgstr "Duración"
+
+#. Description
+#: schema/project-level/codelists/modificationType.csv:1
+msgid ""
+"This modification describes a change to the contract duration. This may be "
+"identified based on changes in `award.contractPeriod` or `contract.period`, "
+"or updates to milestones and payments that appear to exceed the anticipated "
+"`contract.period`."
+msgstr ""
+"Esta modificación describe un cambio a la duración del contrato. Este puede "
+"ser identificado en base a los cambios en `award.contractPeriod` o "
+"`contract.period`, o actualizaciones a hitos y pagos que parezcan exceder el"
+" `contract.period` anticipado."
+
+#. Title
+#: schema/project-level/codelists/modificationType.csv:2
+msgid "Value"
+msgstr "Valor"
+
+#. Description
+#: schema/project-level/codelists/modificationType.csv:2
+msgid ""
+"This modification describes a change to the contract value. This may be "
+"identified based on changes to the sum of `contract.value` (watching for "
+"cases where a contract value is varied, or an additional extension contract "
+"is signed as part of this process), or by monitoring "
+"`contracts.implementation.transactions`."
+msgstr ""
+"Esta modificación describe un cambio en el valor del contrato. Esto puede "
+"ser identificado en base a cambios en la suma de `contract.value` "
+"(observando los casos en los que el valor de un contrato varía, o se firma "
+"un contrato de extensión adicional como parte de este proceso), o "
+"monitoreando `contract.implementation.transactions`."
+
+#. Title
+#: schema/project-level/codelists/modificationType.csv:3
+msgid "Scope"
+msgstr "Alcance"
+
+#. Description
+#: schema/project-level/codelists/modificationType.csv:3
+msgid ""
+"This modification describes a change to the contract scope. This may be "
+"identified by comparing key details from `tender`, `awards` and `contracts`,"
+" or by monitoring relevant documents."
+msgstr ""
+"Esta modificación describe un cambio al alcance del contrato. Esto puede ser"
+" identificado comparando detalles clave de `tender`, `awards` y `contracts` "
+"o monitoreando documentos relevantes."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:1
+msgid "Buyer"
+msgstr "Comprador"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:1
+msgid ""
+"A buyer is an entity whose budget will be used to pay for goods, works or "
+"services related to a contract."
+msgstr ""
+"Un comprador es una entidad cuyo presupuesto se utilizará para pagar bienes,"
+" obras o servicios relacionados con un contrato."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:2
+msgid "Procuring entity"
+msgstr "Entidad de adquisición"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:2
+msgid ""
+"The entity managing the procurement. This can be different from the buyer "
+"who pays for, or uses, the items being procured."
+msgstr ""
+"La entidad que está administrando la adquisición. Esta puede ser diferente "
+"del comprador que paga, o usa, los artículos que están siendo adquiridos."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:3
+msgid "Supplier"
+msgstr "Proveedor"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:3
+msgid "An entity awarded or contracted to provide goods, works or services."
+msgstr ""
+"Una entidad adjudicada o contratada para proveer bienes, obras o servicios."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:4
+msgid "Tenderer"
+msgstr "Licitante"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:4
+msgid "All entities who submit a tender."
+msgstr "Todas las entidades que presentan una oferta."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:5
+msgid "Funder"
+msgstr "Financiador"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:5
+msgid ""
+"The funder is an entity providing money or finance for this contracting "
+"process or project."
+msgstr ""
+"El financiador es una entidad que provee dinero o financiamiento para este "
+"proceso de contratación o proyecto."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:6
+msgid "Enquirer"
+msgstr "Persona que solicita información"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:6
+msgid ""
+"A party who has made an enquiry during the enquiry phase of a contracting "
+"process."
+msgstr ""
+"Una parte que ha realizado un pedido de información durante la fase de "
+"solicitudes de información de un proceso de contratación."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:7
+msgid "Payer"
+msgstr "Pagador"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:7
+msgid "A party making a payment from a transaction."
+msgstr "Una parte que hace un pago en una transacción."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:8
+msgid "Payee"
+msgstr "Beneficiario"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:8
+msgid "A party in receipt of a payment from a transaction."
+msgstr "Una parte que recibe un pago en una transacción."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:9
+msgid "Review body"
+msgstr "Órgano de revisión"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:9
+msgid ""
+"A party responsible for the review of this procurement process. This party "
+"often has a role in any challenges made to the contract award."
+msgstr ""
+"Una parte responsable de la revisión de este proceso de adquisición. Esta "
+"parte tiene a menudo un papel en cualquier cuestionamiento hecho a la "
+"adjudicación del contrato."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:10
+msgid "Interested party"
+msgstr "Parte interesada"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:10
+msgid ""
+"A party that has expressed an interest in the contracting process: for "
+"example, by purchasing tender documents or submitting clarification "
+"questions."
+msgstr ""
+"Una parte que ha expresado interés en el proceso de contratación: por "
+"ejemplo, comprando documentación del concurso o presentando preguntas "
+"aclaratorias."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:11
+msgid "Public Authority"
+msgstr "Autoridad Pública"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:11
+msgid ""
+"The entity responsible for developing the infrastructure assets and/or "
+"delivering the public services in this project."
+msgstr ""
+"La entidad responsable de desarrollar los activos de infraestructura y/o de "
+"entregar los servicios públicos en este proyecto."
+
+#. Title
+#: schema/project-level/codelists/partyRole.csv:12
+msgid "Administrative Entity"
+msgstr "Entidad Administrativa"
+
+#. Description
+#: schema/project-level/codelists/partyRole.csv:12
+msgid "The entity responsible for contract administration."
+msgstr "La entidad responsable de la administración de contratos."
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:1
+msgid "Education"
+msgstr "Educación"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:1
+msgid ""
+"Education, including schools, universities and other learning and training "
+"facilities"
+msgstr ""
+"Educación, incluyendo escuelas, universidades y otras instalaciones de "
+"aprendizaje y entrenamiento."
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:2
+msgid "Health"
+msgstr "Salud"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:2
+msgid "Health, including hospitals, healthcare and human services"
+msgstr "Salud, incluyendo hospitales, servicios humanos y de la salud"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:3
+msgid "Energy"
+msgstr "Energía"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:3
+msgid ""
+"Energy, including electric power generation, and the transmission and "
+"distribution of electricity, oil and gas, for example: power plants, power "
+"lines, gas pipelines"
+msgstr ""
+"Energía, incluyendo generación de energía eléctrica, y la transmisión y "
+"distribución de la electricidad, combustible y gas, por ejemplo: plantas de "
+"energía, líneas eléctricas y gasoductos."
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:4
+msgid "Communications"
+msgstr "Comunicaciones"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:4
+msgid ""
+"Communications, including ICT, IT, telecommunications, postal facilities, "
+"high-speed internet, broadband"
+msgstr ""
+"Comunicaciones, incluyendo ICT, IT, telecomunicaciones, instalaciones "
+"postales, internet de alta velocidad, ancho de banda"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:5
+msgid "Water and waste"
+msgstr "Agua y residuos"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:5
+msgid "Water and waste, including sanitation and wastewater"
+msgstr "Agua y residuos, incluyendo saneamiento y aguas residuales"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:6
+msgid "Governance"
+msgstr "Gobernanza"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:6
+msgid ""
+"Governance, including government accommodations, public buildings, "
+"government offices; justice, courts; emergency services / response, local "
+"security; security, prisons, corrections; defence, military"
+msgstr ""
+"Gobernanza, incluyendo instalaciones del gobierno, edificios públicos, "
+"oficinas gubernamentales; justicia, cortes; servicios de emergencia y "
+"respuesta a emergencias, seguridad local; seguridad, prisiones, "
+"correccionales; defensa, fuerzas armadas"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:7
+msgid "Economy"
+msgstr "Economía"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:7
+msgid "Economy, including agribusiness, agriculture, science and environment"
+msgstr "Economía, incluyendo agronegocios, agricultura, ciencia y ambiente"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:8
+msgid "Culture, sports and recreation"
+msgstr "Cultura, deportes y recreación"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:8
+msgid ""
+"Culture, sports and recreation, including tourism, parks and green areas"
+msgstr ""
+"Cultura, deportes y recreación, incluyendo turismo, parques y áreas verdes"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:9
+msgid "Transport"
+msgstr "Transporte"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:9
+msgid ""
+"Transport. A more detailed breakdown may be provided using the "
+"transport.[mode] codes"
+msgstr ""
+"Transporte. Se puede proveer un desglose más detallado usando los códigos "
+"transport.[mode]."
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:10
+msgid "Air transport"
+msgstr "Transporte aéreo"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:10
+msgid "Air transport, including airports, airways and aviation"
+msgstr "Transporte aéreo, incluyendo aeropuertos, vías aéreas y aviación"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:11
+msgid "Water transport"
+msgstr "Transporte fluvial"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:11
+msgid "Water transport, including ports and inland waterways"
+msgstr "Transporte fluvial, incluyendo puertos y navegación interior"
+
+#. Title
+#. Description
+#: schema/project-level/codelists/projectSector.csv:12
+msgid "Rail transport"
+msgstr "Transporte ferroviario"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:13
+msgid "Road transport"
+msgstr "Transporte terrestre"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:13
+msgid ""
+"Road transport, including roads, highways, streets, tunnels and bridges"
+msgstr ""
+"Transporte terrestre, incluyendo rutas, carreteras, calles, túneles y "
+"puentes"
+
+#. Title
+#: schema/project-level/codelists/projectSector.csv:14
+msgid "Urban transport"
+msgstr "Transporte urbano"
+
+#. Description
+#: schema/project-level/codelists/projectSector.csv:14
+msgid ""
+"Urban transport, including mass transit, urban mobility, buses, cycling, "
+"walking and taxi"
+msgstr ""
+"Transporte urbano, incluyendo tránsito masivo, mobilidad urbana, buses, "
+"ciclismo, vías peatonales y taxis"
+
+#. Title
+#. Description
+#: schema/project-level/codelists/projectSector.csv:15
+msgid "Social housing"
+msgstr "Viviendas sociales"
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:1
+msgid "Identification"
+msgstr "Identificación"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:1
+msgid ""
+"Identification refers to the decision to develop a project within the budget"
+" and programme of a project owner (the public entity responsible for "
+"executing the budget)."
+msgstr ""
+"Identificación se refiere a la decisión de desarrollar un proyecto dentro "
+"del presupuesto y programa de un dueño del proyecto (la entidad pública "
+"responsable de ejecutar el presupuesto)."
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:2
+msgid "Preparation"
+msgstr "Preparación"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:2
+msgid ""
+"Preparation covers the feasibility study, environmental and social impact "
+"assessment, general scoping of the project, establishing the packaging and "
+"procurement strategy, preliminary statutory requirements on environmental "
+"and land impacts, and the resulting budget authorization."
+msgstr ""
+"La preparación cubre el estudio de factibilidad, la evaluación del impacto "
+"medioambiental y social, el alcance general del proyecto, el marco y la "
+"estrategia de adquisiciones, requerimientos legales preliminares sobre el "
+"impacto medioambiental y el terreno, y la resultante actualización del "
+"presupuesto."
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:3
+msgid "implementation"
+msgstr "Implementación"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:3
+msgid ""
+"Implementation covers the procurement and implementation of the group of "
+"works or services (such as design and supervision) to be delivered under the"
+" project, including works or services performed by the procuring entity. "
+"This differs from the definition of 'implementation' in OCDS, which covers "
+"the implementation but not the procurement."
+msgstr ""
+"La implementación cubre las adquisiciones y la implementación del conjunto "
+"de trabajos o servicios (tales como diseño y supervisión) a ser entregados "
+"bajo el proyecto, incluyendo trabajos o servicios realizados por la entidad "
+"compradora. Esto difiere de la definición de 'implementación' en OCDS, que "
+"cubre la implementación pero no las adquisiciones."
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:4
+msgid "Completion"
+msgstr "Finalización"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:4
+msgid ""
+"Completion covers the handover of the assets and close-out activities with "
+"details of the final scope, cost, and delivery time."
+msgstr ""
+"La finalización cubre el traspaso de los activos y las actividades de cierre"
+" con detalles del alcance, costo y fecha de entrega finales."
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:5
+msgid "Completed"
+msgstr "Completado"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:5
+msgid "Close-out activities were completed, and this project is inactive."
+msgstr ""
+"Las actividades de cierre fueron completadas y este proyecto está inactivo."
+
+#. Title
+#: schema/project-level/codelists/projectStatus.csv:6
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. Description
+#: schema/project-level/codelists/projectStatus.csv:6
+msgid ""
+"This project was cancelled before close-out activities were completed, and "
+"is inactive. Cancellation can occur anytime after identification."
+msgstr ""
+"Este proyecto fue cancelado antes de que las actividades de cierre fueran "
+"completadas, y está inactivo. La cancelación puede ocurrir en cualquier "
+"momento después de la identificación."
+
+#. Description
+#: schema/project-level/codelists/projectType.csv:1
+msgid "The primary focus of this project is the construction of a new asset."
+msgstr ""
+"El foco principal de este proyecto es la construcción de un nuevo activo."
+
+#. Title
+#: schema/project-level/codelists/projectType.csv:2
+#: schema/project-level/codelists/relatedProject.csv:2
+msgid "Rehabilitation"
+msgstr "Rehabilitación"
+
+#. Description
+#: schema/project-level/codelists/projectType.csv:2
+msgid ""
+"The primary focus of this project is the rehabilitation of an existing "
+"asset."
+msgstr ""
+"El foco principal de este proyecto es la rehabilitación de un activo "
+"existente."
+
+#. Title
+#: schema/project-level/codelists/projectType.csv:3
+#: schema/project-level/codelists/relatedProject.csv:3
+msgid "Replacement"
+msgstr "Reemplazo"
+
+#. Description
+#: schema/project-level/codelists/projectType.csv:3
+msgid ""
+"The primary focus of this project is the replacement of an existing asset."
+msgstr ""
+"El foco principal de este proyecto es el reemplazo de un activo existente."
+
+#. Title
+#: schema/project-level/codelists/projectType.csv:4
+#: schema/project-level/codelists/relatedProject.csv:4
+msgid "Expansion"
+msgstr "Expansión"
+
+#. Description
+#: schema/project-level/codelists/projectType.csv:4
+msgid ""
+"The primary focus of this project is the expansion of an existing asset."
+msgstr ""
+"El enfoque primario de este proyecto es la expansión de un activo existente."
+
+#. Description
+#: schema/project-level/codelists/relatedProject.csv:1
+msgid ""
+"The related project is the initial construction of the set of infrastructure"
+" assets."
+msgstr ""
+"El proyecto relacionado es la construcción inicial del conjunto de activos "
+"de infraestructura."
+
+#. Description
+#: schema/project-level/codelists/relatedProject.csv:2
+msgid ""
+"The related project might result in the rehabilitation of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en la rehabilitación del mismo "
+"conjunto de activos de infraestructura."
+
+#. Description
+#: schema/project-level/codelists/relatedProject.csv:3
+msgid ""
+"The related project might result in the replacement of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en el reemplazo del mismo conjunto de"
+" activos de infraestructura."
+
+#. Description
+#: schema/project-level/codelists/relatedProject.csv:4
+msgid ""
+"The related project might result in the expansion of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en la expansión del mismo conjunto de"
+" activos de infraestructura."
+
+#. Title
+#: schema/project-level/codelists/relatedProjectScheme.csv:1
+msgid "OC4IDS project id"
+msgstr "ID de proyecto OC4IDS"
+
+#. Description
+#: schema/project-level/codelists/relatedProjectScheme.csv:1
+msgid ""
+"An Open Contracting for Infrastructure Data Standards project identifier"
+msgstr ""
+"Un identificador de proyecto de las Contrataciones Abiertas para el Estándar"
+" de Datos sobre Infraestructura."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:1
+msgid "Planning"
+msgstr "Planeación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:1
+msgid ""
+"A contracting process is proposed or planned. Information in the tender "
+"section describes the proposed process. The tender.status field should be "
+"used to identify whether the planning is at an early pipeline stage, or "
+"whether there are detailed plans for a tender developed."
+msgstr ""
+"Se propone o planea un proceso de contratación. La información en la sección"
+" de licitación describe el proceso propuesto. El campo tender.status debe de"
+" usarse para identificar si la planeación está en una etapa temprana o si "
+"hay planes detallados para una licitación. "
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:2
+msgid "Planning update"
+msgstr "Actualización de la planificación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:2
+msgid ""
+"Details of a proposed or planned contracting process are being updated. This"
+" might include addition of information and documents from consultation "
+"engagement activities, revised details or timelines for a proposed "
+"contracting process, or a tender.status update to indicate that a pipeline "
+"proposal has been withdrawn."
+msgstr ""
+"Los detalles del proceso de contratación propuesto o planeado están siendo "
+"actualizados. Esto puede incluir la adición de información y documentos a "
+"partir de actividades de participación y consulta, detalles o líneas de "
+"tiempo revisados para un proceso de contratación propuesto, o una "
+"actualización en `tender.status` para indicar que una propuesta ha sido "
+"retirada."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:3
+msgid "Tender"
+msgstr "Licitación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:3
+msgid ""
+"Providing information about a new tender (call for proposals) process. "
+"Tender release should contain details of the goods or services being sought."
+msgstr ""
+"Provee información sobre una nueva licitación (llamado a propuestas). La "
+"entrega de licitación debe contener detalles de los bienes o servicios que "
+"se buscan."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:4
+msgid "Tender amendment"
+msgstr "Enmienda a licitación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:4
+msgid ""
+"An amendment to an existing tender release. There should be at least one "
+"tender release with the same ocid, but an earlier release date, before a "
+"tenderAmendment is published. The term amendment has legal meaning in many "
+"jurisdictions."
+msgstr ""
+"Una enmienda a un release de licitación (tender) existente. Debería existir "
+"al menos un release de licitación con el mismo ocid, pero con una fecha de "
+"release anterior, antes de publicar un tenderAmendment. El término enmienda "
+"tiene un significado legal en muchas jurisdicciones."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:5
+msgid "Tender update"
+msgstr "Actualización de licitación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:5
+msgid ""
+"An update to an existing tender release. There should be at least one tender"
+" release with the same ocid, but an earlier release date, before a "
+"tenderUpdate is published. An update may add new information or make "
+"corrections to prior published information. It should not be used for formal"
+" legal amendments to a tender, for which the tenderAmendment tag should be "
+"used."
+msgstr ""
+"Una actualización a un release de licitación (tender) existente. Debería "
+"existir al menos un release de licitación con el mismo ocid, pero con una "
+"fecha de release anterior, antes de publicar un tenderUpdate. Una "
+"actualización puede agregar nueva información o hacer correcciones a "
+"información publicada previamente. Este no debería ser utilizado para "
+"enmiendas legales a una licitación, para las cuales la etiqueta "
+"tenderAmendment debería ser utilizada."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:6
+msgid "Tender cancellation"
+msgstr "Cancelación de la licitación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:6
+msgid ""
+"The cancellation of an existing tender. There should be at least one release"
+" with the same ocid, but an earlier release date, which provides details of "
+"the tender being cancelled."
+msgstr ""
+"La cancelación de una licitación existente. Debería haber al menos un "
+"release con el mismo ocid, pero con una fecha de release anterior, que "
+"provea los detalles de la licitación que está siendo cancelada."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:7
+msgid "Award"
+msgstr "Adjudicación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:7
+msgid ""
+"Providing information about the award of a contract. One or more award "
+"sections will be present, and the tender section might be populated with "
+"details of the process leading up to the award."
+msgstr ""
+"Se provee información sobre la adjudicación de un contrato. Una o más "
+"secciones de award deben estar presentes, y la sección de tender puede ser "
+"llenada con detalles del proceso que llevó a la adjudicación."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:8
+msgid "Award update"
+msgstr "Actualización de la adjudicación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:8
+msgid ""
+"An update to an existing award release. There should be at least one award "
+"release with the same ocid, but an earlier release date before an "
+"awardUpdate is published. An update may add new information or make "
+"corrections."
+msgstr ""
+"Una actualización a un release de adjudicación (award) existente. Debería "
+"existir al menos un release de adjudicación con el mismo ocid, pero con una "
+"fecha de release anterior, antes de publicar un awardUpdate. Una "
+"actualización puede añadir nueva información o hacer correcciones."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:9
+msgid "Award cancellation"
+msgstr "Cancelación de la adjudicación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:9
+msgid "Providing information about the cancellation of an award."
+msgstr "Provee información sobre la cancelación de una adjudicación."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:10
+msgid "Contract"
+msgstr "Contrato"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:10
+msgid ""
+"Providing information about the details of a contract that has been, or will"
+" be, entered into. The tender section might be populated with details of the"
+" process leading up to the contract, and the award section might contain "
+"details of the award on the basis of which this contract will be signed."
+msgstr ""
+"Se provee información sobre los detalles de un contrato que ha entrado, o "
+"entrará, en vigencia. La sección de tender puede ser llenada con detalles "
+"del proceso que lleva al contrato, y la sección de award puede contener "
+"detalles de la adjudicación en base a la cual este contrato será firmado."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:11
+msgid "Contract update"
+msgstr "Actualización de contrato"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:11
+msgid ""
+"Providing information about updates to a contract. There should be at least "
+"one contract release with the same ocid, but an earlier release date, before"
+" a contractUpdate is published. An update may add new information or make "
+"corrections to prior published information. It should not be used for formal"
+" legal amendments to a contract, for which the contractAmendment tag should "
+"be used."
+msgstr ""
+"Se provee información sobre actualizaciones a un contrato. Debería existir "
+"al menos un release de contrato (contract) con el mismo ocid, pero con una "
+"fecha de release anterior, antes de publicar un contractUpdate. Una "
+"actualización puede agregar nueva información o hacer correcciones a "
+"información publicada previamente. No debería ser utilizado para enmiendas "
+"legales a un contrato, para las cuales se debería usar la etiqueta "
+"contractAmendment."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:12
+msgid "Contract amendment"
+msgstr "Enmienda al contrato"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:12
+msgid ""
+"An amendment to an existing contract release. There should be at least one "
+"contract release with the same ocid, but an earlier release date, before a "
+"contractAmendment is published. The term amendment has legal meaning in many"
+" jurisdictions."
+msgstr ""
+"Una enmienda a un release de contrato existente. Debería existir al menos un"
+" release de contrato con el mismo ocid, pero con una fecha de release "
+"anterior, antes de publicar un contractAmendment. El término enmienda tiene "
+"un significado legal en varias jurisdicciones."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:13
+msgid "Implementation"
+msgstr "Implementación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:13
+msgid ""
+"Providing new information on the implementation of a contracting process."
+msgstr ""
+"Provee información nueva sobre la implementación de un proceso de "
+"contratación"
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:14
+msgid "Implementation update"
+msgstr "Actualización de implementación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:14
+msgid ""
+"Updating existing information provided about the implementation of a "
+"contracting process."
+msgstr ""
+"Actualiza información existente sobre la implementación de un proceso de "
+"contratación."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:15
+msgid "Contract termination"
+msgstr "Terminación de contrato"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:15
+msgid "Providing information at the end of a contracting process."
+msgstr "Provee información al final de un proceso de contratación."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:16
+msgid "Compiled record"
+msgstr "Registro Compilado"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:16
+msgid ""
+"This tag is used only in compiled records, which have merged together "
+"multiple releases to provide a snapshot view of the contract, and a version "
+"history."
+msgstr ""
+"Esta etiqueta se usa sólo en registros compilados, que han reunido múltiples"
+" entregas para proveer una captura del contrato y un historial de versiones."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:17
+msgid "Qualification"
+msgstr "Calificación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:17
+msgid ""
+"Providing information about a new pre-qualification process (to qualify or "
+"pre-select bidders for a tender process)."
+msgstr ""
+"Provee información sobre un nuevo proceso de pre-calificación (para "
+"calificar o preseleccionar oferentes para un proceso de licitación)."
+
+#. Extension
+#: schema/project-level/codelists/releaseTag.csv:17
+#: schema/project-level/codelists/releaseTag.csv:18
+#: schema/project-level/codelists/releaseTag.csv:19
+#: schema/project-level/codelists/releaseTag.csv:20
+#: schema/project-level/codelists/releaseTag.csv:21
+#: schema/project-level/codelists/releaseTag.csv:22
+msgid "OCDS for PPPs Extension"
+msgstr "Extensiones OCDS para APP"
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:18
+msgid "Qualification Update"
+msgstr "Actualización de Calificación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:18
+msgid ""
+"An update to an existing qualification release. There should be at least one"
+" qualification release with the same ocid, but an earlier releaseDate, "
+"before a qualificationUpdate is published. An update may add new information"
+" or make corrections to prior published information. It should not be used "
+"for formal legal amendments to a pre-qualification process, for which the "
+"qualificationAmendment tag should be used."
+msgstr ""
+"Una actualización a una entrega de calificación existente. Debería existir "
+"al menos una entrega de clasificación con el mismo ocid, pero con una fecha "
+"de entrega (releaseDate) más antigua, antes de publicar un "
+"qualificationUpdate. Una actualización puede agregar nueva información o "
+"hacer correcciones sobre información publicada previamente. Este no debería "
+"ser usado para enmiendas legales a un proceso de pre-calificación, para lo "
+"que debería usarse la etiqueta qualificationAmendment."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:19
+msgid "Qualification Amendment"
+msgstr "Enmienda de Calificación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:19
+msgid ""
+"An amendment to an existing qualification release. There should be at least "
+"one qualification release with the same ocid, but an earlier releaseDate, "
+"before a qualificationAmendment is published. The term amendment has legal "
+"meaning in many jurisdictions."
+msgstr ""
+"Una enmienda a un release de calificación existente. Debería haber al menos "
+"un release de clasificación con el mismo ocid, pero con una fecha de entrega"
+" (releaseDate) anterior, antes de publicar un qualificationAmendment. El "
+"término enmienda tiene un significado legal en muchas jurisdicciones."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:20
+msgid "Qualification Cancellation"
+msgstr "Cancelación de Calificación"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:20
+msgid ""
+"The cancellation of an existing pre-qualification process. There should be "
+"at least one release with the same ocid, but an earlier releaseDate, which "
+"provides details of the pre-qualification process being cancelled."
+msgstr ""
+"La cancelación de un proceso de pre-calificación existente. Debería haber al"
+" menos un release con el mismo ocid, pero con una fecha de entrega "
+"(releaseDate) anterior, que provea detalles del proceso de pre-calificación "
+"que está siendo cancelado."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:21
+msgid "Shortlist"
+msgstr "Preselección (lista corta)"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:21
+msgid ""
+"Providing information about the qualification or pre-selection of bidders. "
+"The preQualification section may be populated with details of the process "
+"leading up to the shortlist, and details of qualified or shortlisted bidders"
+" will be provided in the parties section."
+msgstr ""
+"Provee información acerca de la calificación o preselección de ofertantes. "
+"La sección preQualification puede ser llenada con detalles del proceso que "
+"lleva a la preselección, y los detalles de los ofertantes calificados o "
+"preseleccionados serán proveídos en la sección de parties."
+
+#. Title
+#: schema/project-level/codelists/releaseTag.csv:22
+msgid "Shortlist Update"
+msgstr "Actualización de preselección (lista corta)"
+
+#. Description
+#: schema/project-level/codelists/releaseTag.csv:22
+msgid ""
+"An update to an existing shortlist release. There should be at least one "
+"shortlist release with the same ocid, but an earlier releaseDate before an "
+"shortlistUpdate is published. An update may add new information or make "
+"corrections."
+msgstr ""
+"Una actualización a una entrega de preselección existente. Debería haber al "
+"menos una entrega de preselección con el mismo ocid, pero con una fecha de "
+"entrega (releaseDate) anterior, para publicar un shortlistUpdate. Una "
+"actualización puede agregar nueva información o hacer correcciones."

--- a/locale/es/LC_MESSAGES/infrastructuremappings.po
+++ b/locale/es/LC_MESSAGES/infrastructuremappings.po
@@ -1,0 +1,780 @@
+# Translations template for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-06-17 10:46+1200\n"
+"PO-Revision-Date: 2020-06-16 22:47+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: mapping/process-level-implementation.csv
+#: mapping/process-level-procurement.csv mapping/project-level-completion.csv
+#: mapping/project-level-identification.csv
+#: mapping/project-level-preparation.csv
+msgid "CoST IDS element"
+msgstr "Elemento de CoST IDS"
+
+#: mapping/process-level-implementation.csv
+#: mapping/process-level-procurement.csv mapping/project-level-completion.csv
+#: mapping/project-level-identification.csv
+#: mapping/project-level-preparation.csv
+msgid "CoST IDS draft definition"
+msgstr "Definición de CoST IDS"
+
+#: mapping/process-level-implementation.csv
+#: mapping/process-level-procurement.csv mapping/project-level-completion.csv
+#: mapping/project-level-identification.csv
+#: mapping/project-level-preparation.csv
+msgid "Mapping to OC for Infrastructure"
+msgstr "Mapeo a OC para Infraestructura"
+
+#: mapping/process-level-implementation.csv
+#: mapping/process-level-procurement.csv mapping/project-level-completion.csv
+#: mapping/project-level-identification.csv
+#: mapping/project-level-preparation.csv
+msgid "Mapping from OCDS"
+msgstr "Mapeo desde OCDS"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-implementation.csv:1
+msgid ""
+"Contracting process: For each variation, publish an entry with a ``.date`` "
+"and ``.description`` in ``.summary.modifications`` with ``.type`` of "
+"'value'. Provide the contract value before the variation in "
+"``.oldContractValue`` and the contract value after the variation in "
+"``.newContractValue``"
+msgstr ""
+"Proceso de contratación: Por cada variación, publique una entrada con una "
+"fecha (``.date``) y descripción (```.description``) en "
+"``.summary.modifications`` usando el tipo (```.type``) 'value'. Provea el "
+"valor del contrato antes de la variación en ``.oldContractValue`` y el valor"
+" del contrato después de la variación en ``.newContractValue```."
+
+#. Mapping from OCDS
+#: mapping/process-level-implementation.csv:1
+#: mapping/process-level-implementation.csv:2
+msgid ""
+"OCDS: Monitor ``contracts.value`` for changes. Copy "
+"``contracts.amendments.description`` to ``.description`` and "
+"``release.date`` to ``.date``"
+msgstr ""
+"OCDS: Monitoree el campo ``contracts.value`` en busca de cambios. Copie el "
+"valor de ``contracts.amendments.description`` a ``.description`` y el valor "
+"de ``release.date`` a ``.date``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-implementation.csv:2
+msgid ""
+"Contracting process: For each escalation, publish an entry with a ``.date`` "
+"and ``.description`` in ``.summary.modifications`` with ``.type`` of "
+"'value'. Provide the contract value before the escalation in "
+"``.oldContractValue`` and the contract value after the escalation in "
+"``.newContractValue``"
+msgstr ""
+"Proceso de contratación: Por cada ajuste, publique una entrada con una fecha"
+" (``.date``) y descripción (``.description``) en ``.summary.modifications`` "
+"con el tipo (``.type``) 'value'. Provea el valor del contrato antes del "
+"ajuste en ``.oldContractValue`` y el valor del contrato después del ajuste "
+"en``.newContractValue``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-implementation.csv:3
+msgid ""
+"Contracting process: For each variation, publish an entry with a ``.date`` "
+"and ``.description`` in ``.summary.modifications`` with ``.type`` of "
+"'duration'. Provide the contract period before the variation in "
+"``.oldContractPeriod`` and the contract period after the variation in "
+"``.newContractPeriod``"
+msgstr ""
+"Proceso de contratación: Por cada variación, publique una entrada con una "
+"fecha (``.date``) y descripción (``.description``) en "
+"``.summary.modifications`` con el tipo (``.type``) 'duration'. Provea el "
+"periodo del contrato antes de la variación en ``.oldContractPeriod`` y el "
+"periodo del contrato después de la variación en ``.newContractPeriod``"
+
+#. Mapping from OCDS
+#: mapping/process-level-implementation.csv:3
+msgid ""
+"OCDS: Monitor ``contracts.period`` for changes. Copy "
+"``contracts.amendments.description`` to ``.description`` and "
+"``release.date`` to ``.date``"
+msgstr ""
+"OCDS: Monitoree la sección ``contracts.period`` en busca de cambios. Copie "
+"el valor del campo ``contracts.amendments.description`` a ``.description`` y"
+" el valor de ``release.date`` a ``.date``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-implementation.csv:4
+msgid ""
+"Contracting process: For each variation, publish an entry with a ``.date`` "
+"and ``.description`` in ``.summary.modifications`` with ``.type`` of 'scope'"
+msgstr ""
+"Proceso de contratación: Por cada variación, publique una entrada con una "
+"fecha (``.date``) y descripción (``.description``) en "
+"``.summary.modifications`` con el tipo (``.type``) 'scope'"
+
+#. Mapping from OCDS
+#: mapping/process-level-implementation.csv:4
+msgid ""
+"OCDS: Monitor ``contracts.description``, ``contracts.items`` and "
+"``contracts.implementation.milestones`` for changes. Copy "
+"``contracts.amendments.description`` to ``.description`` and "
+"``release.date`` to ``.date``"
+msgstr ""
+"OCDS: Monitoree los campos ``contracts.description``, ``contracts.items`` y "
+"``contracts.implementation.milestones`` en busca de cambios. Copie el valor "
+"del campo ``contracts.amendments.description`` a ``.description`` y el valor"
+" de ``release.date`` a ``.date``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-implementation.csv:5
+#: mapping/process-level-implementation.csv:6
+msgid ""
+"Contracting process: For each variation, provide a ``.rationale`` in "
+"``.summary.modifications``."
+msgstr ""
+"Proceso de contratación: Por cada variación, provea una justificación en el "
+"campo ``.rationale`` de ``.summary.modifications``."
+
+#. Mapping from OCDS
+#: mapping/process-level-implementation.csv:5
+#: mapping/process-level-implementation.csv:6
+msgid "OCDS: Copy ``contracts.amendments.rationale`` to ``.rationale``"
+msgstr ""
+"OCDS: Copie el valor de ``contracts.amendments.rationale`` al campo "
+"``.rationale``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:1
+msgid ""
+"Project Level: Add an entry to ``parties`` with 'procuringEntity' included "
+"in its ``.roles`` | Contracting process: Record the name and identifier in "
+"``.summary.tender.procuringEntity``"
+msgstr ""
+"Nivel de proyecto: Agregue una entrada a ``parties`` con el valor "
+"'procuringEntity' incluido en la lista de ``.roles`` | Proceso de "
+"contratación: Registre el nombre e identificador en "
+"``.summary.tender.procuringEntity``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:1
+msgid ""
+"OCDS: Copy from ``tender.procuringEntity.name`` and "
+"``tender.procuringEntity.id``"
+msgstr ""
+"OCDS: Copie los valores desde ``tender.procuringEntity.name`` y "
+"``tender.procuringEntity.id``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:2
+msgid ""
+"Project Level: Publish the postal address in ``parties.address`` and the "
+"electronic address in ``parties.contactPoint``"
+msgstr ""
+"Nivel de Proyecto: Publique la dirección postal en ``parties.address`` y la "
+"dirección electrónica en ``parties.contactPoint``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:2
+msgid ""
+"OCDS: Check for a party with 'procuringEntity' in ``.roles`` and copy from "
+"``.address`` and ``.contactPoint``"
+msgstr ""
+"OCDS: Busque un participante con el valor 'procuringEntity' en su lista de "
+"``.roles`` y copie los valores de ``.address`` y ``.contactPoint``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:3
+msgid ""
+"Project Level: Add an entry to ``parties`` with 'administrativeEntity' "
+"included in its ``.roles`` | Contracting process: Record the name and "
+"identifier in ``.summary.tender.administrativeEntity``"
+msgstr ""
+"Nivel de Proyecto: Agregue una entrada en ``parties`` con el valor "
+"'administrativeEntity' incluido en ``.roles`` | Proceso de contratación: "
+"Registre el nombre e identificador en "
+"``.summary.tender.administrativeEntity``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:3
+msgid ""
+"OCDS: Check for a party with 'administrativeEntity' in ``.roles`` and copy "
+"from ``.name`` and ``.identifier``"
+msgstr ""
+"OCDS: Busque un participante con el valor 'administrativeEntity' en su lista"
+" de ``.roles`` y copie los valores de ``.name`` y ``.identifier``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:4
+msgid ""
+"Contracting process: Publish in ``.summary.status`` using the "
+"contractingProcessStatus codelist"
+msgstr ""
+"Proceso de contratación: Publique el campo ``.summary.status`` usando la "
+"lista de códigos de contractingProcessStatus"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:4
+msgid ""
+"OCDS: Map following the business logic in the contractingProcessStatus "
+"codelist"
+msgstr ""
+"OCDS: Mapee siguiendo la lógica de negocio en la lista de códigos de "
+"contractingProcessStatus"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:5
+msgid ""
+"Contracting process: Publish in ``.summary.tender.procurementMethodDetails``"
+" and map to ``.summary.tender.procurementMethod``"
+msgstr ""
+"Proceso de contratación: Publique el campo "
+"``.summary.tender.procurementMethodDetails`` y mapee el valor al campo "
+"``.summary.tender.procurementMethod``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:5
+msgid ""
+"OCDS: Copy from ``tender.procurementMethod``; if the OCDS data uses the list"
+" developed for infrastructure monitoring, copy from "
+"``tender.procurementMethodDetails``; otherwise, map from "
+"``tender.procurementMethodDetails`` to this list where possible"
+msgstr ""
+"OCDS: Copie el valor de ``tender.procurementMethod``; si los datos OCDS usan"
+" la lista desarrollada para el monitoreo de proyectos de infraestructura, "
+"copie el valor de ``tender.procurementMethodDetails``; si no, mapee el valor"
+" de ``tender.procurementMethodDetails`` a esta lista si es posible"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:6
+msgid ""
+"Contracting process: Add one or more values to the ``.summary.nature`` "
+"array. (e.g. [\"design\", \"build\"] for a design and build contract)"
+msgstr ""
+"Proceso de contratación: Agregue uno o más valores al array de "
+"``.summary.nature`` (ej. [\"design\", \"build\"] para un contrato de diseño "
+"y construcción)"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:6
+msgid ""
+"OCDS: Map from ``tender.items.classification`` or "
+"``tender.items.additionalClassifications`` or infer from "
+"``tender.description``"
+msgstr ""
+"OCDS: Mapee el valor de ``tender.items.classification`` o "
+"``tender.items.additionalClassifications`` o infiera el valor basándose en "
+"``tender.description``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:7
+msgid "Contracting process: Publish in ``.summary.tender.numberOfTenderers``"
+msgstr ""
+"Proceso de contratación: Publique el campo "
+"``.summary.tender.numberOfTenderers``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:7
+msgid "OCDS: Copy from ``tender.numberOfTenderers``"
+msgstr "OCDS: Copie el valor de ``tender.numberOfTenderers``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:8
+msgid "Contracting process: Publish in ``.summary.tender.costEstimate``"
+msgstr ""
+"Proceso de contratación: Publique el campo ``.summary.tender.costEstimate``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:8
+msgid ""
+"OCDS: Copy from ``tender.value`` of the last release in which "
+"``tender.status`` is 'planning'"
+msgstr ""
+"OCDS: Copie el valor de ``tender.value`` del último release en el cual el "
+"valor de ``tender.status`` es 'planning'"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:9
+msgid "Contracting process: Publish in ``.summary.title``"
+msgstr "Proceso de contratación: Publique el campo ``.summary.title``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:9
+msgid ""
+"OCDS: Copy from ``contracts.title``, ``awards.title`` or ``tender.title``; "
+"for contracting processes with multiple awards or contracts, copy from "
+"``tender.title``"
+msgstr ""
+"OCDS: Copie el valor de ``contracts.title``, ``awards.title`` o "
+"``tender.title``; para los procesos de contratación con múltiples "
+"adjudicaciones o contratos, copie el valor de ``tender.title``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:10
+msgid ""
+"Project Level: Add an entries to ``parties`` with 'supplier' included in "
+"their ``.roles`` | Contracting process: Add the names and identifiers to the"
+" ``.summary.suppliers`` array"
+msgstr ""
+"Nivel de Proyecto: Agregue unas entradas a ``parties`` con el valor "
+"'supplier' incluido en el campo ``.roles`` para cada entrada | Procesos de "
+"contratación: Agregue los nombres e identificadores al array de "
+"``.summary.suppliers``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:10
+msgid ""
+"OCDS: Check for parties with 'supplier' in ``.roles`` and copy from "
+"``.name`` and ``.identifier``, or copy from ``awards.suppliers``"
+msgstr ""
+"OCDS: Busque participantes con el valor 'supplier' en su lista de ``.roles``"
+" y copie los valores de ``.name`` y ``.identifier``, o copie los valores de "
+"``awards.suppliers``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:11
+msgid "Contracting process: Publish in ``.summary.contractValue``"
+msgstr "Proceso de contratación: Publique el campo ``.summary.contractValue``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:11
+msgid ""
+"OCDS: Copy from ``awards.value``; for contracting processes with multiple "
+"awards, use the sum of ``awards.value``"
+msgstr ""
+"OCDS: Copie el valor de ``awards.value``; para los procesos de contratación "
+"con múltiples adjudicaciones, use la suma de ``awards.value``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:12
+msgid ""
+"Contracting process: Publish in ``.summary.description``. Additionally "
+"detailed documentation may be provided as documents within linked releases"
+msgstr ""
+"Procesos de contratación: Publique el campo ``.summary.description``. Se "
+"puede proveer documentación detallada adicional como documentos dentro de "
+"los releases enlazados"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:12
+msgid ""
+"OCDS: Copy from ``contracts.description``, `contracts.items.description`` or"
+" ``contracts.implementation.milestones``; if not available, copy from "
+"``awards.description``, ``awards.items.description``, ``tender.description``"
+" or ``tender.items.description``; for contracting processes with multiple "
+"contracts or awards, copy from ``tender.description`` or "
+"``tender.items.description``."
+msgstr ""
+"OCDS: Copie el valor de ``contracts.description``, "
+"`contracts.items.description`` o ``contracts.implementation.milestones``; si"
+" estos no están disponibles, copie el valor de ``awards.description``, "
+"``awards.items.description``, ``tender.description`` o "
+"``tender.items.description``; para los procesos de contratación con "
+"múltiples contratos o adjudicaciones, copie el valor de "
+"``tender.description`` o ``tender.items.description``."
+
+#. Mapping to OC for Infrastructure
+#: mapping/process-level-procurement.csv:13
+msgid "Contracting process: Publish in ``.summary.contractPeriod``"
+msgstr ""
+"Proceso de contratación: Publique la sección ``.summary.contractPeriod``"
+
+#. Mapping from OCDS
+#: mapping/process-level-procurement.csv:13
+msgid ""
+"OCDS: Copy from ``awards.contractPeriod``; if not available, copy from "
+"``tender.contractPeriod``; for contracting processes with multiple awards, "
+"set ``.startDate`` to the earliest of ``awards.contractPeriod.startDate`` "
+"and ``.endDate`` to the latest of ``awards.contractPeriod.endDate``."
+msgstr ""
+"OCDS: Copie los valores de ``awards.contractPeriod``; si este no está "
+"disponible copie los valores de ``tender.contractPeriod``; para los procesos"
+" de contratación con múltiples adjudicaciones, establezca el campo "
+"``.startDate`` al valor más antiguo de ``awards.contractPeriod.startDate`` y"
+" ``.endDate`` al valor más reciente de ``awards.contractPeriod.endDate``."
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:1
+msgid "Project Level: Publish in ``status``"
+msgstr "Nivel de Proyecto: Publique el campo ``status``"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:1
+msgid "OCDS: Infer from ``tag`` of most recent release"
+msgstr "OCDS: infiera el valor desde el ``tag`` del release más reciente"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:2
+msgid "Project Level: Publish in ``completion/finalValue``"
+msgstr "Nivel de Proyecto: Publique el campo ``completion/finalValue``"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:2
+msgid ""
+"OCDS: Infer projected cost from ``contracts.value`` and infer actual cost "
+"from ``contracts.implementation.finalValue`` (Contract completion "
+"extension); if not available, infer from total of "
+"``contracts.implementation.transactions.value``"
+msgstr ""
+"OCDS: Infiera el costo proyectado usando ``contracts.value`` e infiera el "
+"costo real usando ``contracts.implementation.finalValue`` (extensión de "
+"\"Cumplimiento del contrato\" o \"Contract completion\"); si este no está "
+"disponible, infiera el valor usando el total de los valores en "
+"``contracts.implementation.transactions.value``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:3
+msgid "Project Level: Publish in ``completion/endDate``"
+msgstr "Nivel de Proyecto: Publique el campo ``completion/endDate``"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:3
+msgid ""
+"OCDS: Infer from ``contracts.implementation.endDate`` (Contract completion "
+"extension); if not available, infer from ``contracts.period.endDate``"
+msgstr ""
+"OCDS: Infiera el valor usando ``contracts.implementation.endDate`` "
+"(extensión de \"Cumplimiento de contrato\" o \"Contract completion\"); si no"
+" está disponible, infiera el valor usando ``contracts.period.endDate``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:4
+msgid ""
+"Project Level: Publish free text as ``completion/finalScopeDetails`` and/or "
+"include document with ``.type`` of ``projectScope`` and dates and "
+"descriptions that show this is final scope at completion"
+msgstr ""
+"Nivel de Proyecto: Publique texto libre en el campo "
+"``completion/finalScopeDetails`` y/o incluya un documento con el tipo "
+"(``.type``) ``projectScope`` y las fechas y descripciones que muestren que "
+"este es el alcance final al momento de la finalización"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:4
+msgid ""
+"OCDS: Check ``planning.documents`` for documents with ``.type`` set to "
+"`projectScope` or infer from ``contracts.items`` or "
+"``contracts.implementation.milestones``"
+msgstr ""
+"OCDS: Busque en ``planning.documents`` documentos con el tipo (``.type``) "
+"`projectScope` o infiera el valor a partir de ``contracts.items`` o "
+"``contracts.implementation.milestones``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:5
+msgid ""
+"Project Level: Publish using ``completion/endDateDetails``, "
+"``completion/finalValueDetails`` and ``completion/finalScopeDetails``"
+msgstr ""
+"Nivel de Proyecto: Publique usando los campos ``completion/endDateDetails``,"
+" ``completion/finalValueDetails`` y ``completion/finalScopeDetails``"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:5
+msgid ""
+"OCDS: Infer from ``contracts.implementation.endDateDetails`` and "
+"``contracts.implementation.finalValueDetails`` (Contract completion "
+"extension); if not available, infer from ``contracts.amendments``"
+msgstr ""
+"OCDS: Infiera los valores usando ``contracts.implementation.endDateDetails``"
+" y ``contracts.implementation.finalValueDetails`` (extensión de "
+"\"Cumplimiento del contrato\" o \"Contract completion\"); si estos no están "
+"disponibles, infiera el valor usando ``contracts.amendments``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-completion.csv:6
+msgid ""
+"Project Level: Publish in ``documents``, with ``.type`` set to 'finalAudit' "
+"and include a short description and/or a link to a document providing "
+"details"
+msgstr ""
+"Nivel de Proyecto: Publique en la sección de ``documents``, usando el tipo "
+"(``.type``) 'finalAudit' e incluya una descripción corta y/o un enlace a un "
+"documento con más detalles"
+
+#. Mapping from OCDS
+#: mapping/project-level-completion.csv:6
+msgid ""
+"OCDS: Check ``contracts.implementation.documents`` for documents with "
+"``.type`` set to 'finalAudit'"
+msgstr ""
+"OCDS: Busque en ``contracts.implementation.documents`` documentos que tengan"
+" el tipo (``.type``)  'finalAudit'"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:1
+msgid ""
+"Project Level: Add an entry to ``parties`` with 'publicAuthority' included "
+"in its ``.roles``"
+msgstr ""
+"Nivel de Proyecto: Agregue una entrada a ``parties`` con el valor "
+"'publicAuthority' incluido en ``.roles``"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:1
+msgid ""
+"OCDS: Check for parties with 'buyer' or 'publicAuthority' in ``.roles`` and "
+"infer from ``.name``"
+msgstr ""
+"OCDS: Busque partes que contengan los valores 'buyer' o 'publicAuthority' en"
+" ``.roles`` e infiera el valor usando el campo ``.name``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:2
+msgid ""
+"Project Level: Publish in ``sector``, with any additional sectors in "
+"``additionalClassifications``"
+msgstr ""
+"Nivel de Proyecto: Publique el campo ``sector``, con cualquier sector "
+"adicional en la lista de ``additionalClassifications``"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:2
+msgid ""
+"OCDS: Map from ``planning.project.sector`` (Budget and projects extension, "
+"PPP profile)"
+msgstr ""
+"OCDS: Mapee el valor de ``planning.project.sector`` (extensión de "
+"Presupuestos y Proyectos, perfil de APP)"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:3
+msgid "Project Level: Publish in ``additionalClassifications``"
+msgstr ""
+"Nivel de Proyecto: Publique la sección de ``additionalClassifications``"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:3
+msgid ""
+"OCDS: Copy from ``planning.project.additionalClassifications`` (Budget and "
+"projects extension, PPP profile)"
+msgstr ""
+"OCDS: Copie la sección de ``planning.project.additionalClassifications`` "
+"(extensión de Presupuestos y Proyectos, perfil de APP)"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:4
+msgid "Project Level: Publish in ``title``"
+msgstr "Nivel de Proyecto: Publique el campo ``title``"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:4
+msgid ""
+"OCDS: Copy from ``planning.project.title`` (Budget and projects extension, "
+"PPP profile); if not available, infer from ``tender.title``"
+msgstr ""
+"OCDS: Copie el valor de ``planning.project.title`` (extensión de "
+"Presupuestos y Proyectos, perfil de APP); si este no está disponible, "
+"infiera el valor a partir de ``tender.title``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:5
+msgid ""
+"Project Level: Publish using the ``locations`` fields as an address, "
+"geometry (point/line/polygon) or gazetteer entry"
+msgstr ""
+"Nivel de Proyecto: Publique usando los campos de ``locations`` como una "
+"dirección, geometría (punto/línea/polígono) o una entrada en un diccionario "
+"geográfico"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:5
+msgid ""
+"OCDS: Copy from ``planning.project.locations`` (Budget and projects "
+"extension, PPP profile); if not available, infer from "
+"``tender.items.deliveryLocation`` or ``tender.items.deliveryAddress`` "
+"(Location extension)"
+msgstr ""
+"OCDS: Copie los valores de ``planning.project.locations`` (extensión de "
+"Presupuestos y Proyectos, perfil de APP); si este no está disponible, "
+"infiera los valores a partir de ``tender.items.deliveryLocation`` o "
+"``tender.items.deliveryAddress`` (extensión de Ubicación)"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:6
+msgid ""
+"Project Level: Publish in ``purpose``; if classified against a codelist, "
+"also publish in ``additionalClassifications``."
+msgstr ""
+"Nivel de Proyecto: Publique el campo ``purpose``; si está clasificado usando"
+" una lista de códigos, también publique en la sección de "
+"``additionalClassifications``."
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:6
+msgid ""
+"OCDS: Infer from ``planning.rationale`` and check ``planning.documents`` for"
+" documents with ``.type`` set to 'needsAssessment'"
+msgstr ""
+"OCDS: Infiera el valor usando ``planning.rationale`` y busque en "
+"``planning.documents`` documentos con el tipo (``.type``) 'needsAssessment'"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-identification.csv:7
+msgid "Project Level: Publish in ``description``"
+msgstr "Nivel de Proyecto: Publique el campo ``description``"
+
+#. Mapping from OCDS
+#: mapping/project-level-identification.csv:7
+msgid ""
+"OCDS: Copy from ``planning.project.description`` (Budgets and projects "
+"extension, PPP profile); if not available, infer from ``tender.description``"
+msgstr ""
+"OCDS: Copie el valor de ``planning.project.description`` (extensión de "
+"Presupuestos y Proyectos, perfil de APP); si este no está disponible, "
+"infiera el valor a partir de ``tender.description``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:1
+msgid ""
+"Project Level: Publish in ``documents``, with ``.type`` set to "
+"'projectScope' and include a short description and/or a link to a document "
+"providing details"
+msgstr ""
+"Nivel de Proyecto: Publique en la sección de ``documents``, con el tipo "
+"(``.type``) 'projectScope' e incluya una descripción corta y/o un enlace a "
+"un documento con más detalles"
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:1
+msgid ""
+"OCDS: Check ``planning.documents`` for documents with ``.type`` set to "
+"`projectScope` or infer from ``tender.items`` or ``tender.milestones``"
+msgstr ""
+"OCDS: Busque en ``planning.documents`` documentos con el tipo (``.type``) "
+"`projectScope` o infiera el valor a partir de ``tender.items`` o "
+"``tender.milestones``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:2
+msgid ""
+"Project Level: Publish in ``documents``, with ``.type`` set to "
+"'environmentalImpact' and include a short description and/or a link to a "
+"document providing details."
+msgstr ""
+"Nivel de Proyecto: Publique en la sección de ``documents``, con el tipo "
+"(``.type``) 'environmentalImpact' e incluya una descripción corta y/o un "
+"enlace a un documento con más detalles."
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:2
+msgid ""
+"OCDS: Check ``planning.documents`` for documents with ``.type`` set to "
+"'environmentalImpact'"
+msgstr ""
+"OCDS: Busque en ``planning.documents`` documentos con el tipo (``.type``) "
+"'environmentalImpact'"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:3
+msgid ""
+"Project Level: Publish in ``documents``, with ``.type`` set to "
+"'landAndSettlementImpact' and include a short description and/or a link to a"
+" document providing details."
+msgstr ""
+"Nivel de Proyecto: Publique en la sección de ``documents``, con el tipo "
+"(``.type``) 'landAndSettlementImpact' e incluya una descripción corta y/o un"
+" enlace a un documento con más detalles."
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:3
+msgid ""
+"OCDS: Check ``planning.documents`` for documents with ``.type`` set to "
+"'landAndSettlementImpact`"
+msgstr ""
+"OCDS: Busque en ``planning.documents`` documentos con el tipo (``.type``) "
+"'landAndSettlementImpact`"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:4
+msgid ""
+"Project Level: Publish in the ``.address`` and ``.contactPoint`` of the "
+"party with 'publicAuthority' included in its ``.roles``"
+msgstr ""
+"Nivel de Proyecto: Publique en las secciones ``.address`` y "
+"``.contactPoint`` del participante con el valor 'publicAuthority' incluido "
+"en ``.roles``"
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:4
+msgid ""
+"OCDS: Check for a party with 'buyer' or 'publicAuthority' in ``.roles`` and "
+"infer from ``.address`` and ``.contactPoint``"
+msgstr ""
+"OCDS: Busque un participante con los valores 'buyer' o 'publicAuthority' en "
+"`.roles`` e infiera los valores usando ``.address`` y ``.contactPoint``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:5
+msgid ""
+"Project Level: If a funding organization is the project owner, add 'funder' "
+"to the ``.roles`` of the existing entry in ``parties``. Otherwise, add a new"
+" entry to ``parties`` for each funding organization with 'funder' included "
+"in its ``.roles``. When information on the amount provided by each funder is"
+" available, use ``budget/budgetBreakdown`` to provide details"
+msgstr ""
+"Nivel de Proyecto: Si una organización financiadora es la dueña del "
+"proyecto, agregue el valor 'funder' a la lista de ``.roles`` para la entrada"
+" existente en ``parties``. De otra manera, agregue una nueva entrada a "
+"``parties`` para cada organización financiadora con el valor ``funder`` "
+"incluido en ``.roles``. Cuando la información sobre el monto proveído por "
+"cada organización está disponible, use ``budget/budgetBreakdown`` para "
+"proveer más detalles"
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:5
+msgid ""
+"OCDS: Infer from ``planning.budgetBreakdown.sourceParty`` (Budget breakdown "
+"extension); if not available, check for parties with 'funder' in ``.roles`` "
+"and infer from ``.name``"
+msgstr ""
+"OCDS: Infiera el valor a partir de ``planning.budgetBreakdown.sourceParty`` "
+"(extensión de \"Desglose del Presupuesto\"); si este no está disponible, "
+"busque participantes con el valor 'funder' en su lista de ``.roles`` e "
+"infiera el valor usando ``.name``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:6
+msgid "Project Level: Publish in ``budget/amount``"
+msgstr "Nivel de Proyecto: Publique el campo ``budget/amount``"
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:6
+msgid "OCDS: Infer from ``budget/amount``"
+msgstr "OCDS: Infiera el valor usando ``budget/amount``"
+
+#. Mapping to OC for Infrastructure
+#: mapping/project-level-preparation.csv:7
+msgid ""
+"Project Level: Publish in ``budget/approvalDate`` and include additional "
+"document with ``.type`` of 'budgetApproval' if required"
+msgstr ""
+"Nivel de Proyecto: Publique el campo ``budget/approvalDate`` e incluya "
+"documentos adicionales con el tipo (``.type``) 'budgetApproval' si es "
+"necesario"
+
+#. Mapping from OCDS
+#: mapping/project-level-preparation.csv:7
+msgid ""
+"OCDS: Check ``planning.documents`` for a document with ``.type`` set to "
+"'budgetApproval' or check ``planning.milestones`` for a milestone with "
+"``.type`` set to 'approval' and infer from ``.dateMet``"
+msgstr ""
+"OCDS: Busque en ``planning.documents`` un documento con el tipo (``.type``) "
+"'budgetApproval' o busque en ``planning.milestones`` un hito con el tipo "
+"(``.type``) 'approval' e infiera el valor usando ``.dateMet``"

--- a/locale/es/LC_MESSAGES/infrastructureschema.po
+++ b/locale/es/LC_MESSAGES/infrastructureschema.po
@@ -1,0 +1,2380 @@
+# Translations template for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# 
+# Translators:
+# Charlie Pinder <charlie.pinder@opendataservices.coop>, 2019
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-05-14 11:41+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. /title
+#: schema/project-level/project-package-schema.json:1
+msgid "Schema for an OC4IDS project package"
+msgstr "Esquema para un paquete de proyecto OC4IDS"
+
+#. /description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"A package of OC4IDS projects. Note that all projects within a package must "
+"have a unique project identifier."
+msgstr ""
+"Un paquete de proyectos OC4IDS. Note que todos los proyectos dentro de un "
+"paquete deben tener un identificador único de proyecto."
+
+#. /properties/uri/title
+#: schema/project-level/project-package-schema.json:1
+msgid "Package identifier"
+msgstr "Identificador de paquete"
+
+#. /properties/uri/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"The URI of this package that identifies it uniquely in the world. "
+"Recommended practice is to use a dereferenceable URI, where a persistent "
+"copy of this package is available."
+msgstr ""
+"La URI de este paquete, que lo identifica como único en el mundo. Una "
+"práctica recomendada es usar una URI diferenciable donde esté disponible una"
+" copia constante de este paquete."
+
+#. /properties/publishedDate/title
+#: schema/project-level/project-package-schema.json:1
+msgid "Published date"
+msgstr "Fecha de publicación"
+
+#. /properties/publishedDate/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"The date that this package was published. If this package is generated 'on "
+"demand', this date should reflect the date of the last change to the "
+"underlying contents of the package."
+msgstr ""
+"La fecha en que se publicó este paquete. Si se generó 'bajo demanda', esta "
+"fecha debe de reflejar la fecha del último cambio y los contenidos "
+"subyacentes del paquete."
+
+#. /properties/version/title
+#: schema/project-level/project-package-schema.json:1
+msgid "OC4IDS schema version"
+msgstr "Versión del esquema OC4IDS"
+
+#. /properties/version/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"The version of the OC4IDS schema used in this package, expressed as "
+"major.minor. For example: 0.9"
+msgstr ""
+"La versión del esquema OC4IDS usada en este paquete, expresada en el formato"
+" mayor.menor. Por ejemplo: 0.9"
+
+#. /properties/projects/title
+#: schema/project-level/project-package-schema.json:1
+msgid "Projects"
+msgstr "Proyectos"
+
+#. /properties/projects/description
+#: schema/project-level/project-package-schema.json:1
+msgid "A list of projects included in this package, in OC4IDS format."
+msgstr "Una lista de proyectos incluidos en este paquete, en formato OC4IDS."
+
+#. /properties/publisher/title
+#: schema/project-level/project-package-schema.json:1
+msgid "Publisher"
+msgstr "Publicador"
+
+#. /properties/publisher/description
+#: schema/project-level/project-package-schema.json:1
+msgid "Information to uniquely identify the publisher of this package."
+msgstr ""
+"Información que identifica de manera única al publicador de este paquete."
+
+#. /properties/publisher/properties/name/title
+#. /definitions/ContactPoint/properties/name/title
+#: schema/project-level/project-package-schema.json:1
+#: schema/project-level/project-schema.json:1
+msgid "Name"
+msgstr "Nombre"
+
+#. /properties/publisher/properties/name/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"The name of the organization or department responsible for publishing this "
+"data."
+msgstr ""
+"El nombre de la organización o departamento responsable de publicar estos "
+"datos."
+
+#. /properties/publisher/properties/scheme/title
+#. /definitions/Classification/properties/scheme/title
+#. /definitions/Identifier/properties/scheme/title
+#. /definitions/RelatedProject/properties/scheme/title
+#: schema/project-level/project-package-schema.json:1
+#: schema/project-level/project-schema.json:1
+msgid "Scheme"
+msgstr "Esquema"
+
+#. /properties/publisher/properties/scheme/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"The scheme that holds the unique identifiers used to identify the item being"
+" identified."
+msgstr ""
+"El esquema que tiene los identificadores únicos utilizados para identificar "
+"el artículo que se identifica."
+
+#. /properties/publisher/properties/uid/title
+#: schema/project-level/project-package-schema.json:1
+msgid "uid"
+msgstr "uid"
+
+#. /properties/publisher/properties/uid/description
+#: schema/project-level/project-package-schema.json:1
+msgid "The unique ID for this entity under the given ID scheme."
+msgstr ""
+"El ID único para esta entidad bajo el esquema de identificadores "
+"proporcionado."
+
+#. /properties/publisher/properties/uri/title
+#. /definitions/Location/properties/uri/title
+#. /definitions/Identifier/properties/uri/title
+#: schema/project-level/project-package-schema.json:1
+#: schema/project-level/project-schema.json:1
+msgid "URI"
+msgstr "URI"
+
+#. /properties/publisher/properties/uri/description
+#: schema/project-level/project-package-schema.json:1
+msgid "A URI to identify the publisher."
+msgstr "Una URI para identificar al publicador."
+
+#. /properties/license/title
+#: schema/project-level/project-package-schema.json:1
+msgid "License"
+msgstr "Licencia"
+
+#. /properties/license/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"A link to the license that applies to the data in this package. A Public "
+"Domain Dedication or [Open Definition "
+"Conformant](http://opendefinition.org/licenses/) license is strongly "
+"recommended. The canonical URI of the license should be used. Documents "
+"linked from this file may be under other license conditions."
+msgstr ""
+"Un enlace a la licencia que aplica para los datos en este paquete. Se "
+"recomiendan licencias de Entrega al Dominio Público o [que cumplan con la "
+"Open Definition](http://opendefinition.org/licenses/). Se deberá usar la URI"
+" canónica de la licencia. Los documentos enlazados desde este archivo pueden"
+" estar bajo otras condiciones de licencia."
+
+#. /properties/publicationPolicy/title
+#: schema/project-level/project-package-schema.json:1
+msgid "Publication policy"
+msgstr "Política de publicación"
+
+#. /properties/publicationPolicy/description
+#: schema/project-level/project-package-schema.json:1
+msgid ""
+"A link to a document describing the publisher's [data user "
+"guide](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/guidance/data_user_guide/)."
+msgstr ""
+"Un enlace a un documento que describe la [guía para usuarios de "
+"datos](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/guidance/data_user_guide/)"
+" del publicador."
+
+#. /title
+#: schema/project-level/project-schema.json:1
+msgid "Open Contracting for Infrastructure Data Standard Schema"
+msgstr ""
+"Esquema de Contrataciones Abiertas para el Estándar de Datos sobre "
+"Infraestructura"
+
+#. /description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The Open Contracting for Infrastructure Data Standard (OC4IDS) Schema sets "
+"out a data structure for capturing and exchanging information about "
+"infrastructure projects in line with the disclosure requirements of the "
+"[CoST Infrastructure Data "
+"Standard](http://infrastructuretransparency.org/resource/977/). In the "
+"context of OC4IDS, the term 'project' refers to the development of a set of "
+"infrastructure assets in a specified location, generally the responsibility "
+"of a single procuring entity and budget authority: for example, a highway "
+"overpass or a university campus."
+msgstr ""
+"El Esquema del Contrataciones Abiertas para el Estándar de Datos sobre "
+"Infraestructura (OC4IDs, por sus siglas en inglés) establece una estructura "
+"de datos para capturar e intercambiar información sobre proyectos de "
+"infraestructura, en línea con los requerimientos de publicación del "
+"[Estándar de Datos de Infraestructura "
+"CoST](http://infrastructuretransparency.org/resource/977/). En el contexto "
+"de OC4IDS, el término 'proyecto' se refiere al desarrollo de una serie de "
+"activos de infraestructura en una localización específica, generalmente bajo"
+" la responsabilidad de una sola entidad contratante y  autoridad "
+"presupuestaria: por ejemplo, un puente de autopista o un campus para una "
+"universidad."
+
+#. /properties/id/title
+#: schema/project-level/project-schema.json:1
+msgid "Identifier or Reference"
+msgstr "Identificador o Referencia"
+
+#. /properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A unique identifier or reference number for this infrastructure project, "
+"composed of a project identifier prefix and a local project identifier. For "
+"more information, see the [project identifier guidance](https://standard"
+".open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/guidance/identifiers"
+"/#globally-unique-project-identifiers)."
+msgstr ""
+"Un identificador único o número de referencia para este proyecto de "
+"infraestructura, compuesto de un prefijo de identificador de proyecto y un "
+"identificador local de proyecto. Para más información vea la  [guía de "
+"identificadores de proyecto](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/guidance/identifiers"
+"/#globally-unique-project-identifiers)."
+
+#. /properties/updated/title
+#: schema/project-level/project-schema.json:1
+msgid "Last updated"
+msgstr "Última actualización"
+
+#. /properties/updated/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The date on which project-level information was last updated. This should "
+"not be changed when constituent contracting processes information changes, "
+"unless this project-level data has been updated as a result, or to provide "
+"explanations or justifications for those changes."
+msgstr ""
+"La última fecha en la cual la información a nivel de proyecto fue "
+"actualizada. Esta no debería cambiar cuando la información de los procesos "
+"de contratación constituyentes cambie, a menos que los datos a nivel de "
+"proyecto hayan sido actualizados como consecuencia, o para proveer "
+"explicaciones o justificaciones de estos cambios."
+
+#. /properties/title/title
+#: schema/project-level/project-schema.json:1
+msgid "Project title"
+msgstr "Título del Proyecto"
+
+#. /properties/title/description
+#: schema/project-level/project-schema.json:1
+msgid "The title of the project."
+msgstr "El título del proyecto"
+
+#. /properties/description/title
+#: schema/project-level/project-schema.json:1
+msgid "Project description"
+msgstr "Descripción del proyecto"
+
+#. /properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A description of this project. This should usually be no longer than a "
+"single paragraph."
+msgstr ""
+"Una descripción de este proyecto. Usualmente, este no debería ocupar más de "
+"un solo párrafo."
+
+#. /properties/status/title
+#. /definitions/ContractingProcessSummary/properties/status/title
+#: schema/project-level/project-schema.json:1
+msgid "Status"
+msgstr "Estado"
+
+#. /properties/status/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The current phase or status of this project, from the "
+"[projectStatus](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projectstatus)"
+" codelist."
+msgstr ""
+"La fase o estado actual de este proyecto, de la lista de códigos "
+"[projectStatus](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projectstatus)."
+
+#. /properties/period/title
+#: schema/project-level/project-schema.json:1
+msgid "Project period"
+msgstr "Período del proyecto"
+
+#. /properties/period/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The period over which this project is planned to run. This may be updated "
+"during the preparation phase as information becomes available to more "
+"accurately specify anticipated start and end dates, but should not be "
+"updated during the implementation or completion phases. The planned "
+"completion date of the project should be provided in `period.endDate`, which"
+" can be compared with the actual completion date in `completion.endDate`"
+msgstr ""
+"El periodo sobre el cual se planea que este proyecto correrá. Este puede ser"
+" actualizado durante la fase de preparación a medida que la información está"
+" disponible para especificar con más precisión las fechas de inicio y "
+"finalización anticipadas, pero no debería ser actualizado durante las fases "
+"de implementación y finalización. La fecha planificada de finalización "
+"debería ser proveída en `period.endDate`, que puede ser comparado con la "
+"fecha real de finalización en `completion.endDate`."
+
+#. /properties/sector/title
+#: schema/project-level/project-schema.json:1
+msgid "Project sector"
+msgstr "Sector del proyecto"
+
+#. /properties/sector/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"One or more values from the [projectSector codelist](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projectsector)"
+" representing the sector(s) this project relates to. More detailed sector "
+"breakdown information can be provided using the pattern "
+"[sector].[subsector]. Where subsector codes are used the parent code should "
+"also be included, e.g. `['transport', 'transport.air']`"
+msgstr ""
+"Uno o más valores de la [lista de códigos projectSector](https://standard"
+".open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projectsector)"
+" representando el sector o sectores que se relacionan con este proyecto. Se "
+"puede proveer información de sector más desglosada usando el patrón "
+"[sector].[subsector]. Cuando los códigos de subsector son usados el código "
+"padre debería ser incluido también, por ejemplo `['transport', "
+"'transport.air']`"
+
+#. /properties/purpose/title
+#: schema/project-level/project-schema.json:1
+msgid "Project purpose"
+msgstr "Propósito del proyecto"
+
+#. /properties/purpose/description
+#: schema/project-level/project-schema.json:1
+msgid "The socioeconomic purpose of this project."
+msgstr "El propósito socioeconómico de este proyecto."
+
+#. /properties/additionalClassifications/title
+#: schema/project-level/project-schema.json:1
+msgid "Additional classifications"
+msgstr "Clasificaciones adicionales"
+
+#. /properties/additionalClassifications/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"One or more additional project classifications can be provided to describe "
+"the social or economic focus of the project. This classification may take "
+"place against a locally developed codelist, or a globally established "
+"codelist."
+msgstr ""
+"Pueden proveerse una o más clasificaciones adicionales de proyecto para "
+"describir el enfoque social o económico del proyecto. Esta clasificación "
+"puede hacerse contra una lista de códigos desarrollada localmente, o una "
+"lista de códigos establecida globalmente."
+
+#. /properties/type/title
+#: schema/project-level/project-schema.json:1
+msgid "Project type"
+msgstr "Tipo de proyecto"
+
+#. /properties/type/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Whether the primary focus of this project is the construction of a new asset"
+" or the rehabilitation or replacement of an existing asset, from the "
+"[projectType](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projecttype)"
+" codelist."
+msgstr ""
+"Si el enfoque primario de este proyecto es la construcción de un nuevo "
+"activo o la rehabilitación o reemplazo de un activo existente, de la lista "
+"de códigos [projectType](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#projecttype)."
+
+#. /properties/relatedProjects/title
+#: schema/project-level/project-schema.json:1
+msgid "Related projects"
+msgstr "Proyectos relacionados"
+
+#. /properties/relatedProjects/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"References to projects related to the same set of infrastructure assets as "
+"this project. For example, a project for the replacement of a bridge might "
+"reference the earlier project for its initial construction."
+msgstr ""
+"Referencias a proyectos relacionados al mismo conjunto de activos de "
+"infraestructura de este proyecto. Por ejemplo, un proyecto para el reemplazo"
+" de un puente podría referenciar al proyecto anterior de su construcción "
+"inicial."
+
+#. /properties/assetLifetime/title
+#: schema/project-level/project-schema.json:1
+msgid "Asset lifetime"
+msgstr "Tiempo de vida del activo"
+
+#. /properties/assetLifetime/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The anticipated lifetime of the asset after this project is completed. This "
+"may be provided as either explicit dates or an estimated duration."
+msgstr ""
+"El tiempo de vida previsto para el activo después de que el proyecto esté "
+"completo. Esto puede proveerse como fechas explícitas o como duraciones "
+"estimadas."
+
+#. /properties/locations/title
+#: schema/project-level/project-schema.json:1
+msgid "Project locations"
+msgstr "Ubicaciones del proyecto"
+
+#. /properties/locations/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Information about the location where a project is taking place. One or more "
+"locations may be provided, or the location may be described in a number of "
+"different ways, such as a point location for the central location of "
+"construction, and a gazetteer entry to describe the region where the project"
+" is taking place."
+msgstr ""
+"Información sobre la ubicación en la cual el proyecto toma lugar. Pueden "
+"proveerse una o más ubicaciones, y la ubicación puede describirse de "
+"diferentes maneras, tales como un punto que describe la localización central"
+" de construcción y una entrada en un diccionario geográfico para describir "
+"la región en la cual el proyecto toma lugar."
+
+#. /properties/budget/title
+#: schema/project-level/project-schema.json:1
+msgid "Total project value"
+msgstr "Valor total del proyecto"
+
+#. /properties/budget/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Specify the projected costs or allocated budget for the project (currency "
+"and amount). This cost should include land and property acquisition, "
+"environmental mitigation measures, health and safety provisions, client, "
+"consultant and contractor costs, as well as applicable taxes. Where this "
+"value includes costs incurred directly by the project owner or other "
+"agencies, which are not subject to procurement, then this value is likely to"
+" be higher than the sum of all the linked contracting processes. To indicate"
+" the profile of a budget over time, or the budget coming from different "
+"sources, the extended budgetBreakdown section may be used."
+msgstr ""
+"Especifica los costos proyectados o el presupuesto asignado para el proyecto"
+" (en monto y moneda). Este costo debería incluir la adquisición de tierras y"
+" propiedades, medidas de mitigación ambientales, provisiones de salud y "
+"seguridad, costos de cliente, consultores y contratistas, así como impuestos"
+" aplicables. Cuando este valor incluye costos incurridos directamente por el"
+" dueño del proyecto u otras agencias que no están sujetos a adquisiciones "
+"públicas, entonces este valor probablemente será mayor que la suma de todos "
+"los procesos de contratación enlazados. Para indicar el perfil de un "
+"presupuesto con el tiempo, o que el presupuesto proviene de varias fuentes, "
+"se puede usar la sección extendida budgetBreakdown."
+
+#. /properties/budget/properties/amount/title
+#. /definitions/Value/properties/amount/title
+#. /definitions/BudgetBreakdown/properties/amount/title
+#: schema/project-level/project-schema.json:1
+msgid "Amount"
+msgstr "Monto"
+
+#. /properties/budget/properties/amount/description
+#: schema/project-level/project-schema.json:1
+msgid "The projected costs or allocated budget for the project."
+msgstr "Los costos proyectados o el presupuesto asignado para el proyecto."
+
+#. /properties/budget/properties/requestDate/title
+#: schema/project-level/project-schema.json:1
+msgid "Request date"
+msgstr "Fecha de solicitud"
+
+#. /properties/budget/properties/requestDate/description
+#: schema/project-level/project-schema.json:1
+msgid "The date on which the project budget was requested."
+msgstr "La fecha en la cual el presupuesto del proyecto fue solicitado."
+
+#. /properties/budget/properties/approvalDate/title
+#: schema/project-level/project-schema.json:1
+msgid "Approval date"
+msgstr "Fecha de aprobación"
+
+#. /properties/budget/properties/approvalDate/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The date on which the project budget was approved. Where documentary "
+"evidence for this exists, it may be included among the project documents "
+"with the documentType set to 'budgetApproval'."
+msgstr ""
+"La fecha en la cual el presupuesto del proyecto fue aprobado. Cuando exista "
+"evidencia documentada para esto, puede ser incluida entre los documentos del"
+" proyecto con el tipo de documento (documentType) establecido a "
+"'budgetApproval'."
+
+#. /properties/budget/properties/budgetBreakdown/title
+#: schema/project-level/project-schema.json:1
+msgid "Budget breakdown"
+msgstr "Desglose de presupuesto"
+
+#. /properties/budget/properties/budgetBreakdown/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A detailed breakdown of the budget by period and/or participating funders."
+msgstr ""
+"Un desglose detallado del presupuesto por periodo y/o financiadores "
+"participantes."
+
+#. /properties/parties/title
+#: schema/project-level/project-schema.json:1
+msgid "Parties"
+msgstr "Partes involucradas"
+
+#. /properties/parties/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Information on the parties (organizations, economic operators and other "
+"participants) who are involved in the project and their roles, e.g. buyer, "
+"procuring entity, supplier etc. Organization references elsewhere in the "
+"schema are used to refer back to this entries in this list."
+msgstr ""
+"Información de las partes (organizaciones, instituciones, operadores "
+"económicos y otros participantes) que están involucrados en el proyecto y "
+"sus roles, por ejemplo comprador, entidad de adquisiciones, proveedor, etc. "
+"Se usan referencias a organizaciones en otros lugares del esquema para "
+"apuntar a entradas en esta lista."
+
+#. /properties/publicAuthority/title
+#: schema/project-level/project-schema.json:1
+msgid "Public authority"
+msgstr "Autoridad pública"
+
+#. /properties/publicAuthority/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name and identifier of the public authority that is tendering and "
+"contracting the project. The full details of the entity should be added to "
+"the project-level `parties` array with a `role` of 'publicAuthority'."
+msgstr ""
+"El nombre e identificador de la autoridad pública que está licitando y "
+"contratando el proyecto. Los detalles completos de la entidad deberían ser "
+"añadidos al array de `parties` a nivel de proyecto con el rol (`role`) de "
+"'publicAuthority'."
+
+#. /properties/documents/title
+#. /definitions/ContractingProcessSummary/properties/documents/title
+#: schema/project-level/project-schema.json:1
+msgid "Documents"
+msgstr "Documentos"
+
+#. /properties/documents/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Documentation related to this project. Entries may include a short text summary (plain text, HTML or Markdown), and/or a link to a specific document accessible on the web. \n"
+"\n"
+" At the identification phase, a project scope (documentType: projectScope) is expected. At the preparation phase, environmental impact (documentType: environmentalImpact) and land and settlement impact (documentType: landAndSettlementImpact) documentation is expected. During implementation, procurement documents should be shared at the contracting process level, but key documents may also be provided here. At the completion phase, final audit (documentType: finalAudit) and evaluation (documentType: projectEvaluation) reports and documents are expected."
+msgstr ""
+"Documentación relacionada a este proyecto. Las entradas pueden incluir un resumen breve en texto (texto plano, HTML o Markdown), y/o un enlace a un documento específico accesible en la Web. \n"
+"\n"
+"En la fase de identificación, se espera un documento de alcance del proyecto (documentType: projectScope). En la fase de preparación, se espera documentación sobre impacto ambiental (documentType: environmentalImpact) y sobre impacto en tierras y asentamientos (documentType: landAndSettlementImpact). Durante la implementación, se debería compartir documentos de adquisición a nivel de procesos de contratación, pero documentos clave también pueden proveerse aquí. En la fase de terminación, se esperan reportes y documentos finales de auditoría (documentType: finalAudit) y evaluación (documentType: projectEvaluation)."
+
+#. /properties/contractingProcesses/title
+#: schema/project-level/project-schema.json:1
+msgid "Contracting processes"
+msgstr "Procesos de contratación"
+
+#. /properties/contractingProcesses/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A single project may have a number of related contracting processes (design, construction, monitoring etc.). Project-level data should contain \n"
+"\n"
+" (a) an index of those contracting process; \n"
+"\n"
+" (b) the latest summary information about them; \n"
+"\n"
+"(c) a change history with explanations for any major modifications to contract duration, price or scope.\n"
+"\n"
+" Where OCDS data is published on each contracting process, a link should be provided to each available release of OCDS data (e.g. to each notice or updated notice), and this OCDS data may be used to automatically populate the summary information."
+msgstr ""
+"Un solo proyecto puede tener un número de procesos de contratación relacionados (diseño, construcción, supervisión, etc.). Los datos a nivel de proyecto deberían contener\n"
+"\n"
+"(a) un índice de estos procesos de contratación;\n"
+"\n"
+"(b) la última información resumida acerca de ellos;\n"
+"\n"
+"(c) un historial de cambios con explicaciones sobre cualquier modificación significativa a duraciones de contrato, precio o alcance.\n"
+"\n"
+"Cuando se publican datos OCDS sobre cada proceso de contratación, se debería proveer un enlace a cada entrega disponible de datos OCDS (por ejemplo, a cada aviso o aviso actualizado), y estos datos OCDS podrían ser usados para poblar la información resumida de manera automática."
+
+#. /properties/completion/title
+#: schema/project-level/project-schema.json:1
+msgid "Completion"
+msgstr "Terminación o finalización"
+
+#. /properties/completion/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"This information is provided at project completion, and reflects the final "
+"timing and values relating to the project. The reason for any variation (not"
+" already explained) between the anticipated project scope, period and value "
+"should be detailed."
+msgstr ""
+"Esta información se provee a la finalización del proyecto, y refleja los "
+"tiempos y valores finales relacionados al mismo. La razón para cualquier "
+"variación (que no haya sido explicada aún) entre el alcance, periodo y valor"
+" anticipados debería ser detallada."
+
+#. /properties/completion/properties/endDate/title
+#. /definitions/Period/properties/endDate/title
+#: schema/project-level/project-schema.json:1
+msgid "End date"
+msgstr "Fecha de fin"
+
+#. /properties/completion/properties/endDate/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The actual completion date for the project (compare with the endDate in "
+"project period)."
+msgstr ""
+"La fecha de finalización real para el proyecto (compare con la fecha de "
+"finalización -endDate- en el periodo del proyecto)."
+
+#. /properties/completion/properties/endDateDetails/title
+#: schema/project-level/project-schema.json:1
+msgid "End date details"
+msgstr "Detalles de fecha de fin"
+
+#. /properties/completion/properties/endDateDetails/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Details related to the endDate. This may be a justification for the "
+"project's completion date being different than in the original project."
+msgstr ""
+"Detalles relacionados a la fecha de finalización (endDate). Esto puede ser "
+"una justificación por la cual la fecha de finalización del proyecto es "
+"diferente a la fecha original del proyecto."
+
+#. /properties/completion/properties/finalValue/title
+#. /definitions/ContractingProcessSummary/properties/finalValue/title
+#: schema/project-level/project-schema.json:1
+msgid "Final value"
+msgstr "Valor final"
+
+#. /properties/completion/properties/finalValue/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The total cost of this project at completion (compare with project budget)."
+msgstr ""
+"El costo total del proyecto a la terminación (comparado con el presupuesto "
+"del proyecto)."
+
+#. /properties/completion/properties/finalValueDetails/title
+#: schema/project-level/project-schema.json:1
+msgid "Final value details"
+msgstr "Detalles del valor final"
+
+#. /properties/completion/properties/finalValueDetails/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Details related to the final value. This may be a justification for the "
+"completed project's value being different than in the original or latest "
+"revised budget."
+msgstr ""
+"Detalles relacionados al valor final. Esto puede ser una justificación si el"
+" valor final del proyecto completo es diferente en el presupuesto original o"
+" en el último presupuesto modificado."
+
+#. /properties/completion/properties/finalScope/title
+#: schema/project-level/project-schema.json:1
+msgid "Final scope"
+msgstr "Alcance final"
+
+#. /properties/completion/properties/finalScope/description
+#: schema/project-level/project-schema.json:1
+msgid "A short description of the final scope of the project at completion."
+msgstr ""
+"Una descripción corta del alcance final del proyecto a la finalización."
+
+#. /properties/completion/properties/finalScopeDetails/title
+#: schema/project-level/project-schema.json:1
+msgid "Final scope details"
+msgstr "Detalles de alcance final"
+
+#. /properties/completion/properties/finalScopeDetails/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A reason, explanation or justification for any variation between the "
+"anticipated scope (compare to the projectScope document) and the final scope"
+" at completion. If appropriate, additional details may be included in the "
+"documents section, with a title indicating that these documents will "
+"describe and differences between the planned and completed scope of work."
+msgstr ""
+"Una razón, explicación o justificación para cualquier variación entre el "
+"alcance anticipado (comparado con el documento de projectScope) y el alcance"
+" final a la terminación. Si es apropiado, se pueden incluir detalles "
+"adicionales en la sección de documentos, con un título indicando que estos "
+"documentos describirán diferencias entre el alcance planeado y el alcance "
+"completo del trabajo."
+
+#. /definitions/ContractingProcess/title
+#: schema/project-level/project-schema.json:1
+msgid "Contracting process"
+msgstr "Proceso de contratación"
+
+#. /definitions/ContractingProcess/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Within OC4IDS, a contracting process provides both summary information, and "
+"a log of changes over time, either manually curated, or automatically "
+"generated through linked OCDS releases."
+msgstr ""
+"Dentro de OC4IDS, un proceso de contratación provee información resumida y "
+"un log de campos en el tiempo, ya sea elaborados manualmente o generados "
+"automáticamente a través de entregas OCDS enlazadas."
+
+#. /definitions/ContractingProcess/properties/id/title
+#. /definitions/Modification/properties/id/title
+#. /definitions/Location/properties/id/title
+#. /definitions/BudgetBreakdown/properties/id/title
+#. /definitions/Identifier/title
+#. /definitions/RelatedProject/properties/identifier/title
+#: schema/project-level/project-schema.json:1
+msgid "Identifier"
+msgstr "Identificador"
+
+#. /definitions/ContractingProcess/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"An identifier for this contracting process. If this contracting process has "
+"been assigned an Open Contracting Identifier (OCID) by an external platform "
+"(e.g. national procurement system), that OCID must be recorded here. If "
+"information about this contracting process has been entered manually, or "
+"from a non-OCDS system, then an identifier may be created by the system data"
+" is entered into, following the [guidance for creating contracting process "
+"identifiers](https://standard.open-contracting.org/1.1/en/schema/identifiers"
+"/#contracting-process-identifier-ocid)."
+msgstr ""
+"Un identificador para este proceso de contratación. Si este proceso de "
+"contratación tiene asignado un identificador de Open Contracting (OCID) por "
+"una plataforma externa (ej. sistema nacional de compras públicas), ese OCID "
+"debe ser registrado aquí. Si la información sobre este proceso de "
+"contratación ha sido ingresada manualmente, o por un sistema no compatible "
+"con OCDS, entonces el sistema que registra los datos puede crear un "
+"identificador, siguiendo la [guía para crear identificadores de procesos de "
+"contratación](https://standard.open-"
+"contracting.org/1.1/es/schema/identifiers/#contracting-process-identifier-"
+"ocid)."
+
+#. /definitions/ContractingProcess/properties/summary/title
+#. /definitions/ContractingProcessSummary/title
+#: schema/project-level/project-schema.json:1
+msgid "Summary"
+msgstr "Resumen"
+
+#. /definitions/ContractingProcess/properties/summary/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Summary information about a contracting process, including a log of changes "
+"over time."
+msgstr ""
+"Información resumida sobre un proceso de contratación, incluyendo un "
+"historial de cambios."
+
+#. /definitions/ContractingProcess/properties/releases/title
+#: schema/project-level/project-schema.json:1
+msgid "Linked releases"
+msgstr "Entregas vinculadas"
+
+#. /definitions/ContractingProcess/properties/releases/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The information known about a contracting process changes over time, both as new information becomes available, and as changes are made (such as amendments to scope and value). In the OCDS, each new update of information is known as a 'release'. \n"
+"\n"
+" This section provides space to record a link to each available release."
+msgstr ""
+"La información conocida sobre un proceso de contratación cambia con el tiempo, a medida que nueva información está disponible y a medida que se realizan cambios (como las enmiendas al alcance y valor). En el OCDS, cada nueva actualización de información se conoce como un 'release'.\n"
+"\n"
+"Esta sección provee espacio para registrar un enlace a cada release disponible."
+
+#. /definitions/ContractingProcessSummary/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Summary information about a contracting process and any modifications to it.\n"
+"\n"
+" Summary information can be manually entered and the `modifications` list can be used to manually record a log of changes, with the date and details of each modification.\n"
+"\n"
+" Where OCDS data is available, most summary fields can be derived from OCDS releases, although the exact method to derive data may vary between implementations; and modifications may be identified by comparing a new release to previous releases to check for relevant changes, with the release identifier recorded in `modifications`."
+msgstr ""
+"Información resumida sobre un proceso de contratación y cualquier modificación realizada al mismo.\n"
+"\n"
+"La información resumida puede ser ingresada manualmente, y la lista de modificaciones (`modifications`) puede usarse para registrar manualmente un historial de cambios, con la fecha y los detalles de cada modificación.\n"
+"\n"
+"Cuando hay datos OCDS disponibles, la mayoría de los campos de resumen pueden derivarse de releases OCDS, aunque el método exacto para derivar los datos puede variar entre implementaciones; y las modificaciones pueden ser identificadas comparando un release nuevo con releases previos para  buscar cambios relevantes, y registrando los identificadores de release en `modifications`."
+
+#. /definitions/ContractingProcessSummary/properties/ocid/title
+#: schema/project-level/project-schema.json:1
+msgid "Open Contracting Identifier"
+msgstr "Identificador de Contrataciones Abiertas"
+
+#. /definitions/ContractingProcessSummary/properties/ocid/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"If this contracting process has been assigned an Open Contracting Identifier"
+" (OCID) by an external platform (e.g. national procurement system), that "
+"OCID must be recorded here. Otherwise this field should be omitted."
+msgstr ""
+"Si este proceso de contratación tiene asignado un identificador de Open "
+"Contracting (OCID) por una plataforma externa (ej. sistema nacional de "
+"compras públicas), ese OCID debería ser registrado aquí. De otra manera este"
+" campo debería ser omitido. "
+
+#. /definitions/ContractingProcessSummary/properties/externalReference/title
+#: schema/project-level/project-schema.json:1
+msgid "External reference"
+msgstr "Referencia externa"
+
+#. /definitions/ContractingProcessSummary/properties/externalReference/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"If this contracting process is identified by some external reference number "
+"it may be recorded here."
+msgstr ""
+"Si este proceso de contratación está identificado por algún número de "
+"referencia externa, puede ser registrado aquí."
+
+#. /definitions/ContractingProcessSummary/properties/nature/title
+#: schema/project-level/project-schema.json:1
+msgid "Nature"
+msgstr "Naturaleza"
+
+#. /definitions/ContractingProcessSummary/properties/nature/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Whether this contracting process relates to the design, construction and/or "
+"supervision of the project, from the [contractNature](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#contractnature)"
+" codelist. More than one value may be provided if the contract is for both "
+"design and construction, or both design and supervision, etc."
+msgstr ""
+"Si este proceso de contratación está relacionado con el diseño, construcción"
+" y/o supervisión del proyecto, de la lista de códigos "
+"[contractNature](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#contractnature)."
+" Se puede proveer más de un valor si el contrato es para diseño y "
+"construcción, o diseño y supervisión, etc."
+
+#. /definitions/ContractingProcessSummary/properties/title/title
+#. /definitions/Document/properties/title/title
+#: schema/project-level/project-schema.json:1
+msgid "Title"
+msgstr "Título"
+
+#. /definitions/ContractingProcessSummary/properties/title/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The formal name of this contracting process. Once set, this should not "
+"normally by changed."
+msgstr ""
+"El nombre formal de este proceso de contratación. Una vez establecido, esto"
+"  normalmente no debería ser cambiado."
+
+#. /definitions/ContractingProcessSummary/properties/description/title
+#. /definitions/Modification/properties/description/title
+#. /definitions/Classification/properties/description/title
+#. /definitions/Location/properties/description/title
+#. /definitions/BudgetBreakdown/properties/description/title
+#. /definitions/Document/properties/description/title
+#: schema/project-level/project-schema.json:1
+msgid "Description"
+msgstr "Descripción"
+
+#. /definitions/ContractingProcessSummary/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The description should summarize the purpose of this contract and the "
+"initial scope of the work to be carried out under the contract."
+msgstr ""
+"La descripción debería resumir el propósito de este contrato y el alcance "
+"inicial del trabajo a ser llevado a cabo bajo el contrato."
+
+#. /definitions/ContractingProcessSummary/properties/status/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The status of this contracting process. Drawn from the "
+"[contractingProcessStatus codelist](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#contractingprocessstatus)."
+msgstr ""
+"El estatus de este proceso de contratación. Extraído de la [lista de códigos"
+" de contractingProcessStatus](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#contractingprocessstatus)."
+
+#. /definitions/ContractingProcessSummary/properties/tender/title
+#: schema/project-level/project-schema.json:1
+msgid "Tender"
+msgstr "Licitación o concurso"
+
+#. /definitions/ContractingProcessSummary/properties/tender/description
+#: schema/project-level/project-schema.json:1
+msgid "The activities undertaken in order to enter into a contract."
+msgstr "Las actividades llevadas a cabo para celebrar un contrato."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procurementMethod/title
+#: schema/project-level/project-schema.json:1
+msgid "Procurement method"
+msgstr "Método de adquisición"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procurementMethod/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Specify tendering method using the [method codelist](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#method) (open, selective, limited, "
+"direct)."
+msgstr ""
+"Especifica el método de licitación usando la [lista de códigos de "
+"método](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#method) (open, selective, limited, "
+"direct)."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procurementMethodDetails/title
+#: schema/project-level/project-schema.json:1
+msgid "Procurement method details"
+msgstr "Detalles del método de contratación"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procurementMethodDetails/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Additional detail on the procurement method used. This field should be used "
+"to record an agreed list of procurement process types, such as: "
+"International Competitive Bidding, National Competitive Bidding, Donor "
+"Procurement Rules, Framework or Direct Award."
+msgstr ""
+"Detalles adicionales sobre el método de adquisición usado. Este campo "
+"debería ser usado para registrar una lista convenida de tipos de procesos de"
+" adquisición, tales como Oferta Competitiva Internacional, Oferta "
+"Competitiva Nacional, Reglas de Adquisiciones de Donantes, Adjudicaciones "
+"Marco o Adjudicaciones Directas."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/costEstimate/title
+#: schema/project-level/project-schema.json:1
+msgid "Cost estimate"
+msgstr "Costo estimado"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/costEstimate/description
+#: schema/project-level/project-schema.json:1
+msgid "The pre-tender estimated value of the contracting process."
+msgstr "El valor estimado pre-licitación del proceso de contratación."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/numberOfTenderers/title
+#: schema/project-level/project-schema.json:1
+msgid "Number of tenderers"
+msgstr "Número de licitantes"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/numberOfTenderers/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The number of parties who placed a bid during this contracting process."
+msgstr ""
+"El número de partes que presenta una oferta dutante este proceso de "
+"contratación."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/tenderers/title
+#: schema/project-level/project-schema.json:1
+msgid "Tenderers"
+msgstr "Licitantes"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/tenderers/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"All parties who submit a bid on a tender. More detailed information on bids "
+"and the bidding organization can be provided using the bid extension in a "
+"linked OCDS release."
+msgstr ""
+"Todas las partes que presentan una oferta en una licitación. Se puede "
+"proveer información más detallada sobre ofertas y la organización licitante "
+"usando la extensión de Ofertas en un release OCDS enlazado."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procuringEntity/title
+#: schema/project-level/project-schema.json:1
+msgid "Procuring entity"
+msgstr "Entidad de adquisiciones "
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/procuringEntity/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name and identifier of the procuring entity responsible for this "
+"contracting process. The full details of the entity should be added to the "
+"project-level `parties` array with a `role` of 'procuringEntity'."
+msgstr ""
+"El nombre e identificador de la entidad contratante responsable por este "
+"proceso de contratación. Los detalles completos de la entidad deberían ser "
+"añadidos al array de `parties` a nivel de proyecto con el rol (`role`) de "
+"'procuringEntity'."
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/administrativeEntity/title
+#: schema/project-level/project-schema.json:1
+msgid "Administrative entity"
+msgstr "Entidad administrativa"
+
+#. /definitions/ContractingProcessSummary/properties/tender/properties/administrativeEntity/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name and identifier of the entity responsible for contract "
+"administration if this is different from the procuring entity. The full "
+"details of the entity should be added to the project-level `parties` array "
+"with a `role` of 'administrativeEntity'."
+msgstr ""
+"El nombre e identificador de la entidad responsable de la administración de "
+"contratos, si esta es diferente a la entidad contratante. Los detalles "
+"completos de esta entidad deberían ser añadidos al array de `parties` a "
+"nivel de proyecto con el rol (`role`) de 'administrativeEntity'."
+
+#. /definitions/ContractingProcessSummary/properties/suppliers/title
+#: schema/project-level/project-schema.json:1
+msgid "Suppliers"
+msgstr "Proveedores"
+
+#. /definitions/ContractingProcessSummary/properties/suppliers/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name and identifier for each supplier for this contracting process. The "
+"full details of each supplier should be added to the project-level `parties`"
+" array with a `role` of 'supplier'."
+msgstr ""
+"El nombre e identificador de cada proveedor para este proceso de "
+"contratación. Los detalles completos de cada proveedor deberían ser añadidos"
+" al array de `parties` a nivel de proyecto con el rol (`role`) de "
+"'supplier'."
+
+#. /definitions/ContractingProcessSummary/properties/contractValue/title
+#: schema/project-level/project-schema.json:1
+msgid "Contract value"
+msgstr "Valor del contrato"
+
+#. /definitions/ContractingProcessSummary/properties/contractValue/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The initial value of the contract. Changes to the initial value of the "
+"contract should be recorded in `modifications`."
+msgstr ""
+"El valor inicial del contrato. Los cambios al valor inicial del contrato "
+"deberían registrarse en `modifications`."
+
+#. /definitions/ContractingProcessSummary/properties/contractPeriod/title
+#: schema/project-level/project-schema.json:1
+msgid "Contract period"
+msgstr "Periodo de contrato"
+
+#. /definitions/ContractingProcessSummary/properties/contractPeriod/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The initial duration of the contract. Changes to the initial duration of the"
+" contract should be recorded in `modifications`."
+msgstr ""
+"La duración inicial del contrato. Los cambios a la duración inicial del "
+"contrato deberían registrarse en `modifications`."
+
+#. /definitions/ContractingProcessSummary/properties/finalValue/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"This should be provided when the contracting process is complete. This may "
+"be derived from the sum of `contract.implementation.transactions` values in "
+"linked OCDS data where available. In other cases, it may need to be "
+"identified and entered manually based on other project documentation."
+msgstr ""
+"Esto debería proveerse cuando el proceso de contratación esté completo. "
+"Puede ser derivado de la suma de de los valores en "
+"`contract.implementation.transactions` en los datos OCDS enlazados cuando "
+"estos estén disponibles. En otro caso, puede ser necesario identificar e "
+"ingresar manualmente el valor en base a otra documentación del proyecto."
+
+#. /definitions/ContractingProcessSummary/properties/documents/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Additional documentation about this contracting process may be provided "
+"here, including reports and evaluations produced through a monitoring "
+"process, or links to web pages where further information about this process "
+"can be found. Where OCDS releases are published, further documents may be "
+"found by looking at the published releases."
+msgstr ""
+"Se puede proveer documentación adicional acerca de este proceso de "
+"contratación aquí, incluyendo reportes y evaluaciones producidas durante un "
+"proceso de monitoreo, o enlaces a páginas web donde se puede encontrar más "
+"información sobre este proceso. Cuando hay releases OCDS publicados, más "
+"documentos pueden ser encontrados mirando los releases publicados."
+
+#. /definitions/ContractingProcessSummary/properties/modifications/title
+#: schema/project-level/project-schema.json:1
+msgid "Modifications"
+msgstr "Modificaciones"
+
+#. /definitions/ContractingProcessSummary/properties/modifications/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Details of changes to the duration, price, scope or other significant "
+"features of the contracting process should be logged here."
+msgstr ""
+"Detalles de los cambios a la duración, precio, alcance u otras "
+"características significativas del procesos de contratación deberían ser "
+"registrados aquí."
+
+#. /definitions/LinkedRelease/title
+#: schema/project-level/project-schema.json:1
+msgid "Release"
+msgstr "Entrega"
+
+#. /definitions/LinkedRelease/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A release of data represents the information known or updated at a "
+"particular point in time."
+msgstr ""
+"Una entrega de datos (release) representa la información conocida o "
+"actualizada en un punto particular en el tiempo."
+
+#. /definitions/LinkedRelease/properties/id/title
+#. /definitions/Classification/properties/id/title
+#. /definitions/Document/properties/id/title
+#. /definitions/Identifier/properties/id/title
+#: schema/project-level/project-schema.json:1
+msgid "ID"
+msgstr "ID"
+
+#. /definitions/LinkedRelease/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A unique identifier for this update of information. This should be taken "
+"from the OCDS `release.id`, if available."
+msgstr ""
+"Un identificador único para esta actualización de la información. Este "
+"debería ser tomado del campo OCDS `release.id`, si está disponible."
+
+#. /definitions/LinkedRelease/properties/tag/title
+#: schema/project-level/project-schema.json:1
+msgid "Release tag"
+msgstr "Etiqueta de entrega"
+
+#. /definitions/LinkedRelease/properties/tag/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"One or more values from the [releaseTag](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#release-tag) codelist used to "
+"indicate the information contained in this release, and the stage of the "
+"contracting process it represents. This should be filled from the OCDS "
+"`release.tag`, if available."
+msgstr ""
+"Uno o más valores de la lista de códigos [releaseTag](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#release-tag) usados para indicar la"
+" información contenida en este release, y la etapa en el proceso de "
+"contratación que representa. Este debería ser llenado a partir del campo "
+"OCDS `release.tag`, si está disponible."
+
+#. /definitions/LinkedRelease/properties/date/title
+#. /definitions/Modification/properties/date/title
+#: schema/project-level/project-schema.json:1
+msgid "Date"
+msgstr "Fecha"
+
+#. /definitions/LinkedRelease/properties/date/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The effective date of this release/update. This should be filled from the "
+"OCDS `release.date`, if available."
+msgstr ""
+"La fecha efectiva de este release/actualización. Este debería ser llenado a "
+"partir del campo OCDS `release.date`, si está disponible."
+
+#. /definitions/LinkedRelease/properties/url/title
+#. /definitions/ContactPoint/properties/url/title
+#. /definitions/Document/properties/url/title
+#: schema/project-level/project-schema.json:1
+msgid "URL"
+msgstr "URL"
+
+#. /definitions/LinkedRelease/properties/url/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A URL (web link) to a release package containing the OCDS release, if "
+"available."
+msgstr ""
+"Una URL (enlace Web) a un paquete de releases que contiene el release OCDS, "
+"si está disponible."
+
+#. /definitions/Modification/title
+#: schema/project-level/project-schema.json:1
+msgid "Modification"
+msgstr "Modificación"
+
+#. /definitions/Modification/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Contains a structured description of any changes, along with a free text "
+"justification."
+msgstr ""
+"Contiene una descripción estructurada de los cambios, con una justificación "
+"en texto libre."
+
+#. /definitions/Modification/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid "A local identifier for this modification."
+msgstr "Un identificador local para esta modificación."
+
+#. /definitions/Modification/properties/date/description
+#: schema/project-level/project-schema.json:1
+msgid "The date this modification was recorded."
+msgstr "La fecha en la que esta modificación fue registrada."
+
+#. /definitions/Modification/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Details of the modification. This may be free text, or may be generated "
+"automatically and provide a structured description of the change."
+msgstr ""
+"Detalles de la modificación. Esto puede ser un texto libre, o puede ser "
+"generado automáticamente y proveer una descripción estructurada del cambio."
+
+#. /definitions/Modification/properties/rationale/title
+#: schema/project-level/project-schema.json:1
+msgid "Rationale"
+msgstr "Justificación"
+
+#. /definitions/Modification/properties/rationale/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A summary of the reasons which have led to this modification to the "
+"originally planned scope, period or value."
+msgstr ""
+"Un resumen de las razones que han llevado a esta modificación del alcance, "
+"periodo o valor planeados originalmente."
+
+#. /definitions/Modification/properties/type/title
+#. /definitions/Location/properties/geometry/properties/type/title
+#: schema/project-level/project-schema.json:1
+msgid "Type"
+msgstr "Tipo"
+
+#. /definitions/Modification/properties/type/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A value from the [modificationType](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#modificationtype)"
+" codelist, indicating whether the modification relates to the duration, "
+"value, scope or other aspect of the contract."
+msgstr ""
+"Un valor de la lista de códigos [modificationType](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#modificationtype),"
+" indicando si la modificación está relacionada a la duración, valor, alcance"
+" u otro aspecto del contrato."
+
+#. /definitions/Modification/properties/releaseID/title
+#: schema/project-level/project-schema.json:1
+msgid "Release ID"
+msgstr "ID de Entrega"
+
+#. /definitions/Modification/properties/releaseID/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The identifier for the OCDS release this modification relates to. The "
+"referenced release should appear in the list of linked releases for this "
+"contracting process."
+msgstr ""
+"El identificador para la entrega OCDS relacionado a esta modificación. La "
+"entrega referenciada debería aparecer en la lista de entregas enlazadas para"
+" este proceso de contratación."
+
+#. /definitions/Modification/properties/oldContractValue/title
+#: schema/project-level/project-schema.json:1
+msgid "Old contract value"
+msgstr "Valor anterior del contrato"
+
+#. /definitions/Modification/properties/oldContractValue/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Contract value before the modification, taking into account any prior "
+"modifications."
+msgstr ""
+"Valor del contrato antes de la modificación, tomando en cuenta todas las "
+"modificaciones anteriores."
+
+#. /definitions/Modification/properties/newContractValue/title
+#: schema/project-level/project-schema.json:1
+msgid "New contract value"
+msgstr "Nuevo valor del contrato"
+
+#. /definitions/Modification/properties/newContractValue/description
+#: schema/project-level/project-schema.json:1
+msgid "Contract value after the modification."
+msgstr "Valor del contrato después de la modificación."
+
+#. /definitions/Modification/properties/oldContractPeriod/title
+#: schema/project-level/project-schema.json:1
+msgid "Old contract period"
+msgstr "Período anterior del contrato"
+
+#. /definitions/Modification/properties/oldContractPeriod/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Contract period before the modification, taking into account any prior "
+"modifications."
+msgstr ""
+"Período del contrato antes de la modificación, teniendo en cuenta todas las "
+"modificaciones anteriores."
+
+#. /definitions/Modification/properties/newContractPeriod/title
+#: schema/project-level/project-schema.json:1
+msgid "New contract period"
+msgstr "Nuevo período del contrato"
+
+#. /definitions/Modification/properties/newContractPeriod/description
+#: schema/project-level/project-schema.json:1
+msgid "Contract period after the modification."
+msgstr "Período del contrato después de la modificación."
+
+#. /definitions/Period/title
+#: schema/project-level/project-schema.json:1
+msgid "Period"
+msgstr "Período"
+
+#. /definitions/Period/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Key events during a project or contracting process may have a known start "
+"date, end date, duration, or maximum extent (the latest date the period can "
+"extend to). In some cases, not all of these fields will have known or "
+"relevant values."
+msgstr ""
+"Los eventos clave durante un proyecto o proceso de contratación pueden tener"
+" una fecha de inicio o fin, duración o extensión máxima (la fecha más tardía"
+" a la cual se puede extender el periodo) conocidas. En algunos casos, no "
+"todos estos campos tendrán valores conocidos o relevantes."
+
+#. /definitions/Period/properties/startDate/title
+#: schema/project-level/project-schema.json:1
+msgid "Start date"
+msgstr "Fecha de inicio"
+
+#. /definitions/Period/properties/startDate/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The start date for the period. When known, a precise start date must be "
+"provided."
+msgstr ""
+"La fecha de inicio para el periodo. Cuando se conoce, una fecha precisa de "
+"inicio debe ser proveída."
+
+#. /definitions/Period/properties/endDate/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The end date for the period. When known, a precise end date must be "
+"provided."
+msgstr ""
+"La fecha de finalización para el periodo. Cuando se conoce, una fecha de "
+"finalización precisa debe ser proveída."
+
+#. /definitions/Period/properties/maxExtentDate/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The period cannot be extended beyond this date. This field can be used to "
+"express the maximum available date for extension or renewal of this period."
+msgstr ""
+"El periodo no se puede extender más allá de esta fecha. Este campo puede "
+"usarse para expresar la fecha máxima disponible para la extensión o "
+"renovación de este periodo."
+
+#. /definitions/Period/properties/maxExtentDate/title
+#: schema/project-level/project-schema.json:1
+msgid "Maximum extent"
+msgstr "Extensión máxima"
+
+#. /definitions/Period/properties/durationInDays/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The maximum duration of this period in days. A user interface can collect or"
+" display this data in months or years as appropriate, and then convert it "
+"into days when storing this field. This field can be used when exact dates "
+"are not known. If a startDate and endDate are set, this field, if used, "
+"should be equal to the difference between startDate and endDate. Otherwise, "
+"if a startDate and maxExtentDate are set, this field, if used, should be "
+"equal to the difference between startDate and maxExtentDate."
+msgstr ""
+"La duración máxima de este periodo en días. Una interfaz de usuario puede "
+"recolectar o desplegar esta información en meses o años según sea apropiado,"
+" y luego convertirlo en días al almacenar este campo. Este campo puede ser "
+"usado cuando no se conocen las fechas exactas. Si una fecha de inicio "
+"(startDate) y una fecha de finalización (endDate) están establecidas, este "
+"campo, si es usado, debería ser igual a la diferencia entre startDate y "
+"endDate. De otra manera, si una fecha de inicio y una fecha máxima de "
+"extensión (maxExtentDate) están establecidas, este campo, si es usado, debe "
+"ser igual a la diferencia entre startDate y maxExtentDate."
+
+#. /definitions/Period/properties/durationInDays/title
+#: schema/project-level/project-schema.json:1
+msgid "Duration (days)"
+msgstr "Duración (días)"
+
+#. /definitions/Classification/title
+#: schema/project-level/project-schema.json:1
+msgid "Classification"
+msgstr "Clasificación"
+
+#. /definitions/Classification/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A classification consists of at least two parts: an identifier for the list "
+"(scheme) from which the classification is taken, and an identifier for the "
+"category from that list being applied. It is useful to also publish a text "
+"label and/or URI that users can draw on to interpret the classification."
+msgstr ""
+"Una clasificación consiste en al menos dos partes: un identificador para la "
+"lista (esquema o *scheme*) de la cual se toma la clasificación, y un "
+"identificador para la categoría de esa lista que se está aplicando. Es útil "
+"también publicar una etiqueta y/o URI que los usuadios puedan usar para "
+"interpretar la clasificación."
+
+#. /definitions/Classification/properties/scheme/description
+#: schema/project-level/project-schema.json:1
+msgid "The scheme or codelist from which the classification code is taken."
+msgstr ""
+"El esquema o lista de códigos de la cual se toma el código de clasificación."
+
+#. /definitions/Classification/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid "The classification code taken from the scheme."
+msgstr "El código de clasificación tomado del esquema."
+
+#. /definitions/Classification/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid "A textual description or title for the classification code."
+msgstr "Una descripción textual o título para el código de clasificación."
+
+#. /definitions/Location/title
+#: schema/project-level/project-schema.json:1
+msgid "Delivery Location"
+msgstr "Ubicación de entrega"
+
+#. /definitions/Location/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The location where activity related to this project will be delivered, or "
+"will take place. A location may be described using a geometry (point "
+"location, line or polygon), a gazetteer entry, an address, or a combination "
+"of these."
+msgstr ""
+"La ubicación en la cual la actividad relacionada a este proyecto tomará "
+"lugar. Una ubicación puede describirse usando geometría (punto de "
+"localización, línea o polígono), una entrada en un diccionario geográfico, "
+"una dirección, o una combinación de las anteriores."
+
+#. /definitions/Location/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A local identifier for this location, unique within the array this location "
+"appears in."
+msgstr ""
+"Un identificador local para esta ubicación, único dentro de la lista en la "
+"cual esta ubicación aparece."
+
+#. /definitions/Location/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A name or description of this location. This might include the name(s) of "
+"the location(s), or might provide a human readable description of the "
+"location to be covered. This description may be used in a user-interface."
+msgstr ""
+"Un nombre o descripción de esta ubicación. Esto puede incluir el nombre (o "
+"nombres) de la ubicación, o puede proveer una descripción legible por "
+"humanos de la ubicación que está siendo cubierta. Esta descripción puede ser"
+" usada en una interfaz de usuario."
+
+#. /definitions/Location/properties/geometry/title
+#: schema/project-level/project-schema.json:1
+msgid "Geometry"
+msgstr "Geometría"
+
+#. /definitions/Location/properties/geometry/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"We follow the [GeoJSON standard](http://geojson.org/) to express basic "
+"location information, using longitude, latitude, and (optionally) elevation "
+"values in the [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System) "
+"(EPSG:4326) projection. A point location can be identified by geocoding a "
+"delivery address. For concession licenses, or other contracts covering a "
+"polygon location which is not contained in a known gazetteer, polygon and "
+"multi-polygon can be used."
+msgstr ""
+"Seguimos el [estándar GeoJSON](http://geojson.org/) para expresar "
+"información básica de localización, usando valores de longitud, latitud y "
+"(opcionalmente) elevación en la proyección "
+"[WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System) (EPSG:4326). Un"
+" punto de localización puede ser identificado geocodificando una dirección "
+"de entrega. Para licencias de concesión, u otros contratos que cubren una "
+"localización en polígono que no está contenida en un diccionario geográfico "
+"conocido, polígonos y multi-polígonos pueden ser usados."
+
+#. /definitions/Location/properties/geometry/properties/type/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The type of [GeoJSON Geometry Objects](http://geojson.org/geojson-spec.html"
+"#geometry-objects) being provided. To provide longitude, latitude, and "
+"(optionally) elevation, use 'Point', and enter an array of [longitude, "
+"latitude] or [longitude, latitude, elevation] as the value of the "
+"coordinates field: e.g. [-122.085, 37.42]. Note the capitalization of type "
+"values, in order to maintain compatibility with GeoJSON."
+msgstr ""
+"El tipo de [Objeto Geométrico GeoJSON](http://geojson.org/geojson-spec.html"
+"#geometry-objects) siendo proveído. Para proveer longitud, latitud, y "
+"(opcionalmente) elevación, use el tipo 'Point', e ingrese un array de "
+"[longitud, latitud] o [longitud, latitud, elevación] como el valor del campo"
+" coordinates: ej. [-122.085, 37.42]. Note la capitalización de los valores "
+"de tipo, con el fin de mantener la compatibilidad con GeoJSON."
+
+#. /definitions/Location/properties/geometry/properties/coordinates/title
+#: schema/project-level/project-schema.json:1
+msgid "Coordinates"
+msgstr "Coordenadas"
+
+#. /definitions/Location/properties/geometry/properties/coordinates/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The relevant array of points, e.g. [longitude, latitude] or [longitude, "
+"latitude, elevation], or a nested array of points, for the GeoJSON geometry "
+"being described. The longitude and latitude MUST be expressed in decimal "
+"degrees in the WGS84 (EPSG:4326) projection."
+msgstr ""
+"La lista relevante de puntos, ej. [latitud, longitud] o [latitud, longitud, "
+"elevación], o una lista anidada de puntos, para la geometría GeoJSON siendo "
+"descrita. La longitud y latitud DEBEN ser expresadas en grados decimales en "
+"la proyección WGS84 (EPSG:4326)."
+
+#. /definitions/Location/properties/gazetteer/title
+#: schema/project-level/project-schema.json:1
+msgid "Gazetteer"
+msgstr "Diccionario geográfico"
+
+#. /definitions/Location/properties/gazetteer/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A gazetteer is a geographical index or directory. The specific gazetteer "
+"used should be specified in scheme, and one or more codes from that "
+"gazetteer used in identifier."
+msgstr ""
+"Un diccionario geográfico es un índice o directorio geográfico. El "
+"diccionario específico usado debería ser especificado en 'scheme', y debería"
+" usarse uno o más códigos de ese diccionario en 'identifiers'."
+
+#. /definitions/Location/properties/gazetteer/properties/scheme/title
+#: schema/project-level/project-schema.json:1
+msgid "Gazetteer scheme"
+msgstr "Esquema de diccionario geográfico"
+
+#. /definitions/Location/properties/gazetteer/properties/scheme/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The entry of the selected gazetteer in the gazetteers codelist. The codelist"
+" provides details of services, where available, that can resolve a gazetteer"
+" entry to provide location names."
+msgstr ""
+"La entrada del diccionario geográfico seleccionado en la lista de códigos de"
+" diccionarios geográficos. La lista de códigos provee detalles de servicios,"
+" cuando estén disponibles, que pueden recibir una entrada en el diccionario "
+"y proveer nombres de ubicación."
+
+#. /definitions/Location/properties/gazetteer/properties/identifiers/title
+#: schema/project-level/project-schema.json:1
+msgid "Identifiers"
+msgstr "Identificadores"
+
+#. /definitions/Location/properties/gazetteer/properties/identifiers/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"An array of one or more codes drawn from the gazetteer indicated in scheme."
+msgstr ""
+"Una lista de uno o más códigos extraídos del diccionario geográfico indicado"
+" en el campo scheme."
+
+#. /definitions/Location/properties/uri/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A URI to a further description of the activity location. This may be a human"
+" readable document with information on the location, or a machine-readable "
+"description of the location."
+msgstr ""
+"Una URI a una descripción más detallada de la ubicación de la actividad. "
+"Esto puede ser un documento legible por humanos con información de esta "
+"ubicación, o una descripción legible por máquina de la ubicación."
+
+#. /definitions/Location/properties/address/title
+#. /definitions/Organization/properties/address/title
+#. /definitions/Address/title
+#: schema/project-level/project-schema.json:1
+msgid "Address"
+msgstr "Dirección"
+
+#. /definitions/Location/properties/address/description
+#: schema/project-level/project-schema.json:1
+msgid "A physical address where works will take place."
+msgstr ""
+"Una dirección física donde contactar a las partes involucradas en el "
+"proyecto."
+
+#. /definitions/Value/title
+#: schema/project-level/project-schema.json:1
+msgid "Value"
+msgstr "Valor"
+
+#. /definitions/Value/description
+#: schema/project-level/project-schema.json:1
+msgid "Financial values should be published with a currency attached."
+msgstr ""
+"Los valores financieros deberían ser publicados con una moneda adjunta."
+
+#. /definitions/Value/properties/amount/description
+#: schema/project-level/project-schema.json:1
+msgid "Amount as a number."
+msgstr "Monto como una cifra."
+
+#. /definitions/Value/properties/currency/title
+#: schema/project-level/project-schema.json:1
+msgid "Currency"
+msgstr "Moneda"
+
+#. /definitions/Value/properties/currency/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The currency of the amount, from the closed [currency](https://standard"
+".open-contracting.org/1.1/en/schema/codelists/#currency) codelist."
+msgstr ""
+"La moneda del monto, de la lista de códigos cerrada "
+"[moneda](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/#currency)."
+
+#. /definitions/Organization/title
+#: schema/project-level/project-schema.json:1
+msgid "Organization"
+msgstr "Organización"
+
+#. /definitions/Organization/description
+#: schema/project-level/project-schema.json:1
+msgid "A party (organization)"
+msgstr "Una parte involucrada (organización)"
+
+#. /definitions/Organization/properties/name/title
+#: schema/project-level/project-schema.json:1
+msgid "Common name"
+msgstr "Nombre común"
+
+#. /definitions/Organization/properties/name/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A common name for this organization or other participant in the contracting "
+"process. The identifier object provides a space for the formal legal name, "
+"and so this may either repeat that value, or may provide the common name by "
+"which this organization or entity is known. This field may also include "
+"details of the department or sub-unit involved in this contracting process."
+msgstr ""
+"Un nombre común para esta organización u otro participante en el proceso de "
+"contratación. El objeto identifier provee un espacio para el nombre legal, y"
+" por lo tanto este puede repetir ese valor, o puede proveer el nombre común "
+"por el cual esta organización o entidad es conocida. Este campo también "
+"puede incluir detalles del departamento o sub-unidad involucrado en este "
+"proceso de contratación."
+
+#. /definitions/Organization/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The ID used for cross-referencing to this party from other sections of the "
+"release. This field may be built with the following structure "
+"{identifier.scheme}-{identifier.id}(-{department-identifier})."
+msgstr ""
+"El ID utilizado para hacer referencia a esta parte involucrada desde otras "
+"secciones de la entrega. Este campo puede construirse con la siguiente "
+"estructura {identifier.scheme}-{identifier.id}(-{department-identifier})."
+
+#. /definitions/Organization/properties/id/title
+#: schema/project-level/project-schema.json:1
+msgid "Entity ID"
+msgstr "ID de Entidad"
+
+#. /definitions/Organization/properties/identifier/title
+#: schema/project-level/project-schema.json:1
+msgid "Primary identifier"
+msgstr "Identificador principal"
+
+#. /definitions/Organization/properties/identifier/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The primary identifier for this organization or participant. Identifiers "
+"that uniquely pick out a legal entity should be preferred. Consult the "
+"[organization identifier guidance](https://standard.open-"
+"contracting.org/1.1/en/schema/identifiers/) for the preferred scheme and "
+"identifier to use."
+msgstr ""
+"El identificador primario para esta organización o participante. Los "
+"identificadores que distinguen de forma única a una entidad legal deberían "
+"ser preferidos. Consulte la [guía de identificadores de "
+"organización](https://standard.open-"
+"contracting.org/1.1/es/schema/identifiers/) para el esquema e "
+"identificadores preferidos a utilizar."
+
+#. /definitions/Organization/properties/additionalIdentifiers/title
+#: schema/project-level/project-schema.json:1
+msgid "Additional identifiers"
+msgstr "Identificadores adicionales"
+
+#. /definitions/Organization/properties/additionalIdentifiers/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A list of additional / supplemental identifiers for the organization or "
+"participant, using the [organization identifier guidance](https://standard"
+".open-contracting.org/1.1/en/schema/identifiers/). This can be used to "
+"provide an internally used identifier for this organization in addition to "
+"the primary legal entity identifier."
+msgstr ""
+"Una lista de identificadores adicionales / suplementarios para la "
+"organización o participante, usando la [guía de identificadores de "
+"organización](https://standard.open-"
+"contracting.org/1.1/es/schema/identifiers/). Este puede ser utilizado para "
+"proveer un identificador usado internamente para esta organización en "
+"adición al identificador de entidad legal primario."
+
+#. /definitions/Organization/properties/address/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"An address. This may be the legally registered address of the organization, "
+"or may be a correspondence address for this particular contracting process."
+msgstr ""
+"Una dirección. Esta puede ser la dirección legalmente registrada de la "
+"organización o puede ser una dirección donde se reciba correspondencia para "
+"este proceso de contratación particular."
+
+#. /definitions/Organization/properties/contactPoint/title
+#. /definitions/ContactPoint/title
+#: schema/project-level/project-schema.json:1
+msgid "Contact point"
+msgstr "Punto de contacto"
+
+#. /definitions/Organization/properties/contactPoint/description
+#: schema/project-level/project-schema.json:1
+msgid "Contact details that can be used for this party."
+msgstr "Detalles de contacto que pueden usarse para esta parte involucrada."
+
+#. /definitions/Organization/properties/roles/title
+#: schema/project-level/project-schema.json:1
+msgid "Party roles"
+msgstr "Roles de las partes"
+
+#. /definitions/Organization/properties/roles/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The party's role(s) in the project, using the open "
+"[partyRole](https://standard.open-"
+"contracting.org/profiles/ppp/latest/en/reference/codelists/#partyrole) "
+"codelist."
+msgstr ""
+"El rol o roles de la parte en este proyecto, usando la lista de códigos "
+"abierta [partyRole](https://standard.open-"
+"contracting.org/profiles/ppp/latest/en/reference/codelists/#partyrole)."
+
+#. /definitions/OrganizationReference/properties/name/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name of the party being referenced. This must match the name of an entry"
+" in the parties section."
+msgstr ""
+"El nombre de la parte involucrada al que se hace referencia. Este debe de "
+"ser igual al nombre de una entrada en la sección de partes involucradas."
+
+#. /definitions/OrganizationReference/properties/name/title
+#: schema/project-level/project-schema.json:1
+msgid "Organization name"
+msgstr "Nombre de la Organización"
+
+#. /definitions/OrganizationReference/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The id of the party being referenced. This must match the id of an entry in "
+"the parties section."
+msgstr ""
+"El id de una parte involucrada a la que se hace referencia. Este debe de ser"
+" igual al id de una entrada en la sección de partes involucradas."
+
+#. /definitions/OrganizationReference/properties/id/title
+#: schema/project-level/project-schema.json:1
+msgid "Organization ID"
+msgstr "ID de Organización"
+
+#. /definitions/OrganizationReference/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The id and name of the party being referenced. Used to cross-reference to "
+"the parties section"
+msgstr ""
+"El id y nombre de la parte a la que se hace referencia. Usado para hacer "
+"referencia de la sección de partes"
+
+#. /definitions/OrganizationReference/title
+#: schema/project-level/project-schema.json:1
+msgid "Organization reference"
+msgstr "Referencia de la organización"
+
+#. /definitions/Address/description
+#: schema/project-level/project-schema.json:1
+msgid "An address."
+msgstr "Una dirección."
+
+#. /definitions/Address/properties/streetAddress/title
+#: schema/project-level/project-schema.json:1
+msgid "Street address"
+msgstr "Dirección de la calle"
+
+#. /definitions/Address/properties/streetAddress/description
+#: schema/project-level/project-schema.json:1
+msgid "The street address. For example, 1600 Amphitheatre Pkwy."
+msgstr "La dirección de la calle. Por ejemplo: 1600 Amphitheatre Pkwy."
+
+#. /definitions/Address/properties/locality/title
+#: schema/project-level/project-schema.json:1
+msgid "Locality"
+msgstr "Localidad"
+
+#. /definitions/Address/properties/locality/description
+#: schema/project-level/project-schema.json:1
+msgid "The locality. For example, Mountain View."
+msgstr "La localidad. Por ejemplo: Mountain View."
+
+#. /definitions/Address/properties/region/title
+#: schema/project-level/project-schema.json:1
+msgid "Region"
+msgstr "Región"
+
+#. /definitions/Address/properties/region/description
+#: schema/project-level/project-schema.json:1
+msgid "The region. For example, CA."
+msgstr "La región. Por ejemplo: CA."
+
+#. /definitions/Address/properties/postalCode/title
+#: schema/project-level/project-schema.json:1
+msgid "Postal code"
+msgstr "Código postal"
+
+#. /definitions/Address/properties/postalCode/description
+#: schema/project-level/project-schema.json:1
+msgid "The postal code. For example, 94043."
+msgstr "El código postal. Por ejemplo: 94043"
+
+#. /definitions/Address/properties/countryName/title
+#: schema/project-level/project-schema.json:1
+msgid "Country name"
+msgstr "País"
+
+#. /definitions/Address/properties/countryName/description
+#: schema/project-level/project-schema.json:1
+msgid "The country name. For example, United States."
+msgstr "El nombre del país. Por ejemplo: Estados Unidos."
+
+#. /definitions/ContactPoint/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A person, contact point or department to contact in relation to this "
+"contracting process."
+msgstr ""
+"Una persona, punto de contacto o departamento a contactar en relación a este"
+" proceso de contratación."
+
+#. /definitions/ContactPoint/properties/name/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name of the contact person, department, or contact point, for "
+"correspondence relating to this project."
+msgstr ""
+"El nombre de la persona o departamento de contacto, o punto de contacto, "
+"para la correspondencia relacionada a este proyecto."
+
+#. /definitions/ContactPoint/properties/email/title
+#: schema/project-level/project-schema.json:1
+msgid "Email"
+msgstr "Correo electrónico"
+
+#. /definitions/ContactPoint/properties/email/description
+#: schema/project-level/project-schema.json:1
+msgid "The e-mail address of the contact point/person."
+msgstr "La dirección de correo del punto o persona de contacto."
+
+#. /definitions/ContactPoint/properties/telephone/title
+#: schema/project-level/project-schema.json:1
+msgid "Telephone"
+msgstr "Teléfono"
+
+#. /definitions/ContactPoint/properties/telephone/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The telephone number of the contact point/person. This should include the "
+"international dialing code."
+msgstr ""
+"El número de teléfono del punto o persona de contacto. Este debe de incluir "
+"el código de marcación internacional."
+
+#. /definitions/ContactPoint/properties/faxNumber/title
+#: schema/project-level/project-schema.json:1
+msgid "Fax number"
+msgstr "Número de fax"
+
+#. /definitions/ContactPoint/properties/faxNumber/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The fax number of the contact point/person. This should include the "
+"international dialing code."
+msgstr ""
+"El número de fax del punto o persona de contacto. Este debe de incluir el "
+"código de marcación internacional."
+
+#. /definitions/ContactPoint/properties/url/description
+#: schema/project-level/project-schema.json:1
+msgid "A web address for the contact point/person."
+msgstr "Una dirección web para el punto o persona de contacto."
+
+#. /definitions/BudgetBreakdown/title
+#: schema/project-level/project-schema.json:1
+msgid "Detailed budget breakdown"
+msgstr "Desglose detallado de presupuesto"
+
+#. /definitions/BudgetBreakdown/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"This section allows a detailed budget breakdown to be expressed, covering "
+"multiple budget sources and multiple periods"
+msgstr ""
+"Esta sección permite expresar un desglose detallado del presupuesto, que "
+"cubre múltiples fuentes de presupuesto y múltiples períodos."
+
+#. /definitions/BudgetBreakdown/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid "An identifier for this particular budget entry."
+msgstr "Un identificador para esta entrada de presupuesto en particular."
+
+#. /definitions/BudgetBreakdown/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid "A short free text description of this budget entry."
+msgstr ""
+"Una descripción corta en texto libre para esta entrada de presupuesto."
+
+#. /definitions/BudgetBreakdown/properties/amount/description
+#: schema/project-level/project-schema.json:1
+msgid "The value of the budget line item."
+msgstr "El valor de la línea presupuestaria."
+
+#. /definitions/BudgetBreakdown/properties/uri/title
+#: schema/project-level/project-schema.json:1
+msgid "Linked budget information"
+msgstr "Información vinculada de presupuesto"
+
+#. /definitions/BudgetBreakdown/properties/uri/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A URI pointing directly to a machine-readable information about this budget "
+"entry."
+msgstr ""
+"Una URI apuntando a información legible por máquina sobre esta entrada de "
+"presupuesto."
+
+#. /definitions/BudgetBreakdown/properties/period/title
+#: schema/project-level/project-schema.json:1
+msgid "Budget period"
+msgstr "Periodo presupuestario"
+
+#. /definitions/BudgetBreakdown/properties/period/description
+#: schema/project-level/project-schema.json:1
+msgid "The period covered by this budget entry."
+msgstr "El periodo cubierto por esta entrada de presupuesto."
+
+#. /definitions/BudgetBreakdown/properties/sourceParty/title
+#: schema/project-level/project-schema.json:1
+msgid "Source party"
+msgstr "Parte fuente"
+
+#. /definitions/BudgetBreakdown/properties/sourceParty/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The organization or other party related to this budget entry. If the budget "
+"amount is positive, this indicates a flow of resources from the party to the"
+" contracting process. If the budget amount is negative, it indicates a "
+"payment from the contracting process to this party."
+msgstr ""
+"La organización u otra parte relacionada a esta entrada de presupuesto. Si "
+"el monto del presupuesto es positivo, esto indica un flujo de recursos desde"
+" la parte para este proceso de contratación. Si el monto es negativo, indica"
+" un pago del proceso de contratación a esta parte."
+
+#. /definitions/Document/title
+#: schema/project-level/project-schema.json:1
+msgid "Document"
+msgstr "Documento"
+
+#. /definitions/Document/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Links to, or descriptions of, external documents can be attached at various "
+"locations within the standard. Documents can be supporting information, "
+"formal notices, downloadable forms, or any other kind of resource that ought"
+" to be made public as part of full open contracting."
+msgstr ""
+"Enlaces a, o descripciones de, documentos externos pueden adjuntarse en "
+"varias ubicaciones dentro del estándar. Los documentos pueden ser "
+"información de soporte, anuncios formales, formularios descargables, o "
+"cualquier otro tipo de recurso que debe ser hecho público como parte de las "
+"contrataciones abiertas completas."
+
+#. /definitions/Document/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A local, unique identifier for this document. This field is used to keep "
+"track of multiple revisions of a document through the compilation from "
+"release to record mechanism."
+msgstr ""
+"Identificador local y único para este documento. Este campo se utiliza para "
+"darle seguimiento a las múltiples versiones de un documento en el proceso de"
+" creación de un registro del proceso de contratación (record) que se genera "
+"a partir de las entregas (release)."
+
+#. /definitions/Document/properties/documentType/title
+#: schema/project-level/project-schema.json:1
+msgid "Document type"
+msgstr "Tipo de Documento"
+
+#. /definitions/Document/properties/documentType/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A classification of the document described, using the open "
+"[documentType](https://standard.open-"
+"contracting.org/profiles/ppp/latest/en/reference/codelists/#documenttype) "
+"codelist."
+msgstr ""
+"Una clasificación del documento descrito, usando la lista de códigos abierta"
+" [documentType](https://standard.open-"
+"contracting.org/profiles/ppp/latest/es/reference/codelists/#documenttype)."
+
+#. /definitions/Document/properties/title/description
+#: schema/project-level/project-schema.json:1
+msgid "The document title."
+msgstr "El título del documento."
+
+#. /definitions/Document/properties/description/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Where a link to a full document is provided, the description should provide a 1 - 3 paragraph summary of the information the document contains, and the `pageStart` field should be used to make sure readers can find the correct section of the document containing more information. Where there is no linked document available, the description field may contain all the information required by the current `documentType`. \n"
+"\n"
+"Line breaks in text (represented in JSON using `\\n\\n`) must be respected by systems displaying this information, and systems may also support basic HTML tags (H1-H6, B, I, U, strong, A and optionally IMG) or [markdown syntax](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for formatting."
+msgstr ""
+"Cuando se provee un enlace a un documento completo, la descripción debería proveer un resumen de 1 a 3 párrafos de la información contenida en el documento, y el campo `pageStart` debería ser usado para asegurar que los lectores puedan encontrar la sección correcta del documento que contiene más información. Cuando no haya un documento disponible, el campo de descripción podría contener toda la información requerida bajo el tipo (`documentType`) actual.\n"
+"\n"
+"Los saltos de línea en el texto (representados en JSON como '\\n\\n') deberían ser respetados por los sistemas que despliegan esta información, y los sistemas podrían también soportar etiquetas HTML básicas (H1-H6, B, I, U, strong, A y opcionalmente IMG) o [sintaxis de markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) para formato de texto."
+
+#. /definitions/Document/properties/url/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"This should be a direct link to the document or web page where the "
+"information described by the current documentType exists."
+msgstr ""
+"Esto debería ser un enlace directo al documento o página web donde exista la"
+" información descrita por el documentType actual."
+
+#. /definitions/Document/properties/datePublished/title
+#: schema/project-level/project-schema.json:1
+msgid "Date published"
+msgstr "Fecha de publicación"
+
+#. /definitions/Document/properties/datePublished/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The date on which the document was first published. This is particularly "
+"important for legally important documents such as notices of a tender."
+msgstr ""
+"La fecha de publicación del documento. Esto es particularmente importante "
+"para documentos relevantes desde el punto de vista legal, como los avisos de"
+" licitación."
+
+#. /definitions/Document/properties/dateModified/title
+#: schema/project-level/project-schema.json:1
+msgid "Date modified"
+msgstr "Fecha de modificación"
+
+#. /definitions/Document/properties/dateModified/description
+#: schema/project-level/project-schema.json:1
+msgid "Date that the document was last modified"
+msgstr "Fecha en que se modificó por última vez el documento."
+
+#. /definitions/Document/properties/format/title
+#: schema/project-level/project-schema.json:1
+msgid "Format"
+msgstr "Formato"
+
+#. /definitions/Document/properties/format/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The format of the document, using the open [IANA Media "
+"Types](http://www.iana.org/assignments/media-types/) codelist (see the "
+"values in the 'Template' column), or using the 'offline/print' code if the "
+"described document is published offline. For example, web pages have a "
+"format of 'text/html'."
+msgstr ""
+"El formato del documento, usando la lista de códigos abierta [IANA Media "
+"Types](http://www.iana.org/assignments/media-types/) (vea los valores en la "
+"columna 'Template'), o usando el código 'offline/print' si el documento "
+"descrito está publicado fuera de línea. Por ejemplo, las páginas web tienen "
+"un formato de 'text/html'."
+
+#. /definitions/Document/properties/language/title
+#: schema/project-level/project-schema.json:1
+msgid "Language"
+msgstr "Idioma"
+
+#. /definitions/Document/properties/language/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The language of the linked document using either two-letter "
+"[ISO639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or "
+"extended [BCP47 language tags](http://www.w3.org/International/articles"
+"/language-tags/). The use of lowercase two-letter codes from "
+"[ISO639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is "
+"recommended unless there is a clear user need for distinguishing the "
+"language subtype."
+msgstr ""
+"El lenguaje del documento enlazado usando el "
+"[ISO639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) de dos "
+"letras, o las [etiquetas de lenguaje "
+"BCP47](http://www.w3.org/International/articles/language-tags/) extendidas. "
+"El uso de códigos de dos letras en minúsculas del "
+"[ISO639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) es "
+"recomendado a menos que haya un caso de uso claro que requiera distinguir el"
+" subtipo del lenguaje."
+
+#. /definitions/Document/properties/pageStart/title
+#: schema/project-level/project-schema.json:1
+msgid "Page start"
+msgstr "Página de inicio"
+
+#. /definitions/Document/properties/pageStart/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"When the information referenced exists within a large document, indicate the"
+" first page on which it can be found. This should refer to the printed page "
+"number, not the page number reported by software applications."
+msgstr ""
+"Cuando la información referenciada existe contenida en un documento largo, "
+"indica la primera página en la cual la misma puede ser encontrada. Esto "
+"debería referirse al número de página impresa, no el número de página "
+"reportado por aplicaciones software."
+
+#. /definitions/Document/properties/pageEnd/title
+#: schema/project-level/project-schema.json:1
+msgid "Page end"
+msgstr "Página final"
+
+#. /definitions/Document/properties/pageEnd/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"When the information referenced exists within a large document, indicate the"
+" last page on which it can be found. This should refer to the printed page "
+"number, not the page number reported by software applications."
+msgstr ""
+"Cuando la información referenciada existe contenida en un documento largo, "
+"indica la última página en la cual la misma puede ser encontrada. Esto "
+"debería referise al número de página impresa, no al número de página "
+"reportado por aplicaciones software."
+
+#. /definitions/Document/properties/accessDetails/title
+#: schema/project-level/project-schema.json:1
+msgid "Access details"
+msgstr "Detalles de acceso"
+
+#. /definitions/Document/properties/accessDetails/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A description of any special arrangements required to access this document. "
+"This may include a requirement to register for document access, a fee to be "
+"paid, or the location where documents can be inspected."
+msgstr ""
+"Una descripción de cualquier arreglo especial necesario para acceder a este "
+"documento. Esto puede incluir un requerimiento de registrarse para acceder "
+"al documento, un pago necesario o la ubicación donde los documentos pueden "
+"ser revisados."
+
+#. /definitions/Document/properties/author/title
+#: schema/project-level/project-schema.json:1
+msgid "Author"
+msgstr "Autor"
+
+#. /definitions/Document/properties/author/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The name of the author of these documents. Include the name of individuals "
+"and/or organizations responsible. For example, when a technical "
+"specification was written by a consultant, include the name and organization"
+" of the consultant."
+msgstr ""
+"El nombre del autor de estos documentos. Incluye el nombre de individuos y/o"
+" organizaciones responsables. Por ejemplo, cuando una especificación técnica"
+" fue escrita por un consultor, incluye el nombre y organización del "
+"consultor."
+
+#. /definitions/Identifier/description
+#: schema/project-level/project-schema.json:1
+msgid "A unique identifier for a party (organization)."
+msgstr "Un identificador único para una parte involucrada (organización)."
+
+#. /definitions/Identifier/properties/scheme/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"Organization identifiers should be taken from an existing organization "
+"identifier list. The scheme field is used to indicate the list or register "
+"from which the identifier is taken. This value should be taken from the "
+"[Organization Identifier Scheme](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#organization-identifier-scheme) "
+"codelist."
+msgstr ""
+"Los identificadores de organización deberían ser tomados de una lista de "
+"identificadores de organización existente. El campo scheme es usado para "
+"indicar la lista o registro del cual se toma el identificador. Este valor "
+"debería ser tomado de la lista de códigos de [Esquema de Identificador de "
+"Organización](https://standard.open-contracting.org/1.1/es/schema/codelists"
+"/#organization-identifier-scheme)."
+
+#. /definitions/Identifier/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid "The identifier of the organization in the selected scheme."
+msgstr "El identificador de la organización en el esquema seleccionado."
+
+#. /definitions/Identifier/properties/legalName/title
+#: schema/project-level/project-schema.json:1
+msgid "Legal Name"
+msgstr "Nombre Legal"
+
+#. /definitions/Identifier/properties/legalName/description
+#: schema/project-level/project-schema.json:1
+msgid "The legally registered name of the organization."
+msgstr "El nombre legalmente registrado de la organización."
+
+#. /definitions/Identifier/properties/uri/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A URI to identify the organization, such as those provided by [Open "
+"Corporates](http://www.opencorporates.com) or some other relevant URI "
+"provider. This is not for listing the website of the organization: that can "
+"be done through the URL field of the Organization contact point."
+msgstr ""
+"Una URI para identificar a la organización, como los proveídos por [Open "
+"Corporates](http://www.opencorporates.com) o algún otro proveedor relevante "
+"de URIs. Este campo no debe ser utilizado para especificar el sitio web de "
+"la organización, el cual puede ser especificado en el campo URL del punto de"
+" contacto de la Organización."
+
+#. /definitions/RelatedProject/title
+#: schema/project-level/project-schema.json:1
+msgid "Related project"
+msgstr "Proyecto relacionado"
+
+#. /definitions/RelatedProject/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A reference to a project related to the same set of infrastructure assets as"
+" this project. Generally, related projects either precede or follow on from "
+"the current project."
+msgstr ""
+"Una referencia a un proyecto relacionado al mismo conjunto de activos de "
+"infraestructura de este proyecto. Generalmente, los proyectos relacionados "
+"preceden o siguen al proyecto actual."
+
+#. /definitions/RelatedProject/properties/id/title
+#: schema/project-level/project-schema.json:1
+msgid "Relationship ID"
+msgstr "ID de relación"
+
+#. /definitions/RelatedProject/properties/id/description
+#: schema/project-level/project-schema.json:1
+msgid "A local identifier for this relationship, unique within this array."
+msgstr ""
+"Un identificador local para esta relación, único dentro de este array."
+
+#. /definitions/RelatedProject/properties/scheme/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The identification scheme used by this cross-reference, using the open "
+"[relatedProjectScheme](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#relatedprojectscheme)"
+" codelist."
+msgstr ""
+"El esquema de identificación usado por esta referencia cruzada, usando la "
+"lista de códigos abierta [relatedProjectScheme](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#relatedprojectscheme)."
+
+#. /definitions/RelatedProject/properties/identifier/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The identifier of the related project. If the scheme is 'oc4ids', this must "
+"be an OC4IDS project ID."
+msgstr ""
+"El identificador de este proyecto relacionado. Si el esquema es 'oc4ids', "
+"este debe ser un ID de proyecto de OC4IDS."
+
+#. /definitions/RelatedProject/properties/relationship/title
+#: schema/project-level/project-schema.json:1
+msgid "Relationship"
+msgstr "Relación"
+
+#. /definitions/RelatedProject/properties/relationship/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The type of relationship, using the open [relatedProject](https://standard"
+".open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#relatedproject)"
+" codelist."
+msgstr ""
+"El tipo de relación, usando la lista de códigos abierta "
+"[relatedProject](https://standard.open-"
+"contracting.org/infrastructure/{{version}}/{{lang}}/reference/codelists/#relatedproject)."
+
+#. /definitions/RelatedProject/properties/title/title
+#: schema/project-level/project-schema.json:1
+msgid "Related project title"
+msgstr "Título del proyecto relacionado"
+
+#. /definitions/RelatedProject/properties/title/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"The title of the related project. If referencing an OC4IDS project, this "
+"should match the value of the `title` field of the related project."
+msgstr ""
+"El título del proyecto relacionado. Si referencia a un proyecto OC4IDS, este"
+" debería coincidir con el valor del campo `title` del proyecto relacionado."
+
+#. /definitions/RelatedProject/properties/uri/title
+#: schema/project-level/project-schema.json:1
+msgid "Related project URI"
+msgstr "URI del proyecto relacionado"
+
+#. /definitions/RelatedProject/properties/uri/description
+#: schema/project-level/project-schema.json:1
+msgid ""
+"A URI pointing to a machine-readable document or project package containing "
+"the identified related project."
+msgstr ""
+"Una URI apuntando a un documento legible por máquina o un paquete de "
+"proyectos que contiene el proyecto relacionado identificado."

--- a/locale/es/LC_MESSAGES/projects/index.po
+++ b/locale/es/LC_MESSAGES/projects/index.po
@@ -1,0 +1,453 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/projects/index.md:1
+msgid "Getting started"
+msgstr "Para empezar"
+
+#: ../../docs/projects/index.md:3
+msgid ""
+"The regular disclosure of structured data can greatly enhance the "
+"transparency and accountability of publicly funded construction projects. "
+"Using a common schema to record the information that is needed to monitor "
+"projects can enable more advanced analysis, both within, and across, "
+"infrastructure projects."
+msgstr ""
+"La divulgación regular de datos estructurados puede mejorar en gran medida "
+"la transparencia y la rendición de cuentas en proyectos de construcción "
+"financiados con fondos públicos. Usar un esquema común para registrar la "
+"información necesaria para monitorear proyectos puede permitir análisis más "
+"avanzados, tanto en el ámbito de un solo proyecto como mediante varios "
+"proyectos de infraestructura."
+
+#: ../../docs/projects/index.md:5
+msgid "What is a project?"
+msgstr "¿Qué es un proyecto?"
+
+#: ../../docs/projects/index.md:7
+msgid ""
+"In the context of OC4IDS, the term 'project' refers to an infrastructure "
+"project, defined as the development of a set of infrastructure assets in a "
+"specified location, generally the responsibility of a single procuring "
+"entity and budget authority: for example, a highway overpass or a university"
+" campus."
+msgstr ""
+"En el contexto de OC4IDS, el término 'proyecto' se refiere a un proyecto de "
+"infraestructura, definido como el desarrollo de un conjunto de activos de "
+"infraestructura en una ubicación específica, generalmente bajo la "
+"responsabilidad de una sola entidad contratante y autoridad presupuestaria: "
+"por ejemplo, un puente de autopista o un campus universitario."
+
+#: ../../docs/projects/index.md:9
+msgid ""
+"An infrastructure project may stand alone (e.g. a new hospital), or may form"
+" part of a wider programme of work (e.g. a new rail station, as part of an "
+"extension to a railway line). An infrastructure project is usually "
+"implemented through a series of contracts, and usually involves planning and"
+" coordination at the project-level."
+msgstr ""
+"Un proyecto de infraestructura puede ser independiente (por ejemplo, un "
+"nuevo hospital), o puede formar parte de un programa de trabajo más amplio "
+"(por ejemplo, una estación de trenes, como parte de la extensión de una "
+"línea ferroviaria). Usualmente un proyecto de infraestructura es "
+"implementado mediante una serie de contratos, e involucra planeamiento y "
+"coordinación a nivel de proyecto."
+
+#: ../../docs/projects/index.md:1
+msgid "Tip"
+msgstr "Consejo"
+
+#: ../../None:1
+msgid ""
+"The term \"project\" is used in many contexts to mean different things, for "
+"example:"
+msgstr ""
+"El término \"proyecto\" es usado en muchos contextos para expresar "
+"diferentes cosas, por ejemplo:"
+
+#: ../../None:3
+msgid "a larger programme of work, like the construction of an entire highway"
+msgstr ""
+"un programa de trabajo grande, como la construcción de una autopista "
+"completa"
+
+#: ../../None:4
+msgid ""
+"an investment project, like in National Public Investment Systems (SNIP) in "
+"Latin America"
+msgstr ""
+"un proyecto de inversión, como en los Sistemas Nacionales de Inversión "
+"Pública (SNIP) en Latinoamérica"
+
+#: ../../None:5
+msgid "a project code in a government's budget"
+msgstr "un código de proyecto en el presupuesto de un gobierno"
+
+#: ../../None:7
+msgid ""
+"However, to correctly implement and interpret OC4IDS, the above definition "
+"of an infrastructure project needs to be adhered to."
+msgstr ""
+"Sin embargo, para implementar e interpretar OC4IDS correctamente, uno se "
+"debe adherir a la definición de arriba de un proyecto de infraestructura."
+
+#: ../../docs/projects/index.md:27
+msgid ""
+"![Projects typically involve multiple contracts](../../_static/images"
+"/diagram-project-contracting-process.png)"
+msgstr ""
+"![Los proyectos normalmente involucran múltiples "
+"contratos](../../_static/images/es/diagram-project-contracting-process.png)"
+
+#: ../../docs/projects/index.md:29
+msgid ""
+"Within an infrastructure project, a procuring entity may issue contracts for"
+" its design, construction or supervision. Budgets, plans and impact "
+"assessments are likely to cut across these."
+msgstr ""
+"Dentro de un proyecto de infraestructura, una entidad contratante puede "
+"emitir contratos para el diseño, construcción o supervisión. Presupuestos, "
+"planes y evaluaciones de impacto se aplican frecuentemente a estos."
+
+#: ../../docs/projects/index.md:31
+msgid "What is project-level data?"
+msgstr "¿Qué son los datos a nivel de proyecto?"
+
+#: ../../docs/projects/index.md:33
+msgid ""
+"![Project-level data covers a number of stages](../../_static/images"
+"/diagram-project-phases.png)"
+msgstr ""
+"![Los datos a nivel de proyecto cubren un número de "
+"etapas](../../_static/images/es/diagram-project-phases.png)"
+
+#: ../../docs/projects/index.md:35
+msgid ""
+"[CoST](http://infrastructuretransparency.org/) have developed a framework of"
+" information that should be pro-actively disclosed and kept updated at each "
+"stage. Project-level data covers:"
+msgstr ""
+"[CoST](http://infrastructuretransparency.org/) desarrolló un marco de "
+"información que debería ser publicada y actualizada proactiva y "
+"reactivamente en cada etapa . Los datos a nivel de proyecto cubren:"
+
+#: ../../docs/projects/index.md:37
+msgid ""
+"**identification** - the decision to develop a project within the budget and"
+" programme of a project owner."
+msgstr ""
+"**identificación** - la decisión de desarrollar un proyecto dentro del "
+"presupuesto y programa del dueño del mismo."
+
+#: ../../docs/projects/index.md:38
+msgid ""
+"**preparation** - the feasibility study, environmental and social impact "
+"assessment, general scoping of the project, establishing the packaging and "
+"procurement strategy, preliminary statutory requirements on environmental "
+"and land impacts, and the resulting budget authorization."
+msgstr ""
+"**preparación** - el estudio de factibilidad, la evaluación del impacto "
+"medioambiental y social, el alcance general del proyecto, establecer el "
+"marco y la estrategia de adquisición, requerimientos legales preliminares "
+"sobre impactos medioambientales y al terreno, y la resultante autorización "
+"del presupuesto."
+
+#: ../../docs/projects/index.md:39
+msgid ""
+"**implementation** - covers the procurement and implementation of the "
+"planning, design and works according to the procurement strategy."
+msgstr ""
+"**implementación** - cubre las adquisiciones y la implementación de la "
+"planeación, diseño y trabajos de acuerdo a la estrategia de adquisiciones."
+
+#: ../../docs/projects/index.md:40
+msgid ""
+"**completion** - covers the handover of the assets and close-out activities "
+"with details of the final scope, cost, and delivery time."
+msgstr ""
+"**finalización** - cubre el traspaso de los activos y las actividades de "
+"cierre con detalles del alcance final, costos y tiempos de entrega."
+
+#: ../../docs/projects/index.md:42
+msgid "This framework has been used as the basis for OC4IDS."
+msgstr "Este marco se ha utilizado como la base de OC4IDS."
+
+#: ../../docs/projects/index.md:44
+msgid "How does contracting data fit in?"
+msgstr "¿Cómo encajan los datos de contrataciones?"
+
+#: ../../docs/projects/index.md:46
+msgid ""
+"![Design, build and supervision activities may be delivered using "
+"contracts](../../_static/images/diagram-project-contract-phases.png)"
+msgstr ""
+"![Las actividades de diseño, construcción y supervisión pueden ser "
+"entregadas usando contratos](../../_static/images/es/diagram-project-"
+"contract-phases.png)"
+
+#: ../../docs/projects/index.md:48
+msgid ""
+"The preparation and implementation stages may be delivered using "
+"contractors. This will lead to one or more contracting processes, each with "
+"their own planning, tender, award, contract and implementation stages."
+msgstr ""
+"Las etapas de preparación e implementación pueden ser entregadas usando "
+"contratistas. Esto llevará a uno o más procesos de contratación, cada uno "
+"con su propias etapas de planificación, licitación, adjudicación, contrato e"
+" implementación."
+
+#: ../../docs/projects/index.md:50
+msgid ""
+"Monitoring an infrastructure project may largely involve monitoring the "
+"contracts used to deliver it: particularly any primary construction "
+"contracts."
+msgstr ""
+"El monitoreo de un proyecto de infraestructura puede involucrar en gran "
+"medida el monitoreo de los contratos usados para entregar el proyecto: "
+"particularmente cualquier contrato primario de construcción."
+
+#: ../../docs/projects/index.md:52
+msgid ""
+"It may be possible to [discover and populate some data about infrastructure "
+"projects by looking at contracting data](../../guidance/using), and to use "
+"data from contracting data systems in order to detect updates and "
+"modifications during a contracting process. In other cases, it is simply "
+"necessary to record details of each contract related to an infrastructure "
+"project, and to manually monitor any modifications to these contracts."
+msgstr ""
+"Podría ser posible [descubrir y llenar algunos datos sobre proyectos de "
+"infraestructura mirando los datos de contratación](../../guidance/using), y "
+"usar datos de sistemas de datos de contrataciones para detectar "
+"actualizaciones y modificaciones durante un proceso de contratación. En "
+"otros casos, es simplemente necesario registrar detalles de cada contrato "
+"relacionado a un proyecto de infraestructura, y monitorear manualmente "
+"cualquier modificación a estos contratos."
+
+#: ../../docs/projects/index.md:54
+msgid "How is OC4IDS structured?"
+msgstr "¿Cómo está estructurado OC4IDS?"
+
+#: ../../docs/projects/index.md:56
+msgid ""
+"![OC4IDS is structured in three parts](../../_static/images/diagram-project-"
+"level-data-spec.png)"
+msgstr ""
+"![OC4IDS está estructurado en tres partes](../../_static/images/es/diagram-"
+"project-level-data-spec.png)"
+
+#: ../../docs/projects/index.md:58
+msgid "OC4IDS is structured in three parts:"
+msgstr "OC4IDS está estructurado en tres partes:"
+
+#: ../../docs/projects/index.md:60
+msgid "Project-Level Data"
+msgstr "Datos a nivel de proyecto"
+
+#: ../../docs/projects/index.md:62
+msgid ""
+"Project-level data includes summary information on project identification, "
+"preparation and completion."
+msgstr ""
+"Los datos a nivel de proyecto incluyen información resumida sobre la "
+"identificación, preparación y finalización del proyecto."
+
+#: ../../docs/projects/index.md:64
+msgid "Contracting process summaries"
+msgstr "Resumen de procesos de contratación"
+
+#: ../../docs/projects/index.md:66
+msgid ""
+"The `contractingProcesses` array may be used to provide a summary of each of"
+" the contracting processes that is used to support preparation and "
+"implementation in the `summary` section."
+msgstr ""
+"La lista `contractingProcesses` puede ser usada para proveer un resumen de "
+"cada uno de los procesos de contratación que es usado para apoyar la "
+"preparación e implementación en la sección `summary`."
+
+#: ../../docs/projects/index.md:68
+msgid ""
+"Information on these processes may be manually entered, or, where OCDS data "
+"is available, may be automatically populated from OCDS data via a push or "
+"pull mechanism."
+msgstr ""
+"La información sobre estos procesos puede ser ingresada manualmente o, si "
+"hay datos OCDS disponibles, puede ser llenado automáticamente desde los "
+"datos OCDS mediante un mecanismo \"push\" o \"pull\"."
+
+#: ../../docs/projects/index.md:70
+msgid ""
+"The `modifications` section should be used to record information on changes "
+"to the contracting process, either linked to OCDS releases or recorded "
+"manually."
+msgstr ""
+"La sección `modifications` debería ser usada para registrar información de "
+"los cambios al proceso de contratación, ya sea enlazando a \"releases\" OCDS"
+" o registrando manualmente."
+
+#: ../../docs/projects/index.md:72
+msgid "Contracting process details"
+msgstr "Detalles de porcesos de contratación"
+
+#: ../../docs/projects/index.md:74
+msgid ""
+"Where OCDS data is available, the `contractingProcesses/releases` array "
+"should act as an index of OCDS releases, recording each update to a "
+"contracting process."
+msgstr ""
+"Cuando datos OCDS están disponibles, el array "
+"`contractingProcesses/releases` debería actuar como un índice de releases "
+"OCDS, registrando cada actualización a un proceso de contratación."
+
+#: ../../docs/projects/index.md:76
+msgid ""
+"Explanations of any modifications detected when comparing releases should be"
+" provided in the `modifications` section of the contracting process summary."
+msgstr ""
+"Las explicaciones a cualquier modificación detectada al comparar "
+"\"releases\" deberían proveerse en la sección `modifications` del resumen "
+"del proceso de contratación"
+
+#: ../../docs/projects/index.md:78
+msgid "How can I use OC4IDS?"
+msgstr "¿Cómo puedo usar OC4IDS?"
+
+#: ../../docs/projects/index.md:80
+msgid "If you have an existing infrastructure transparency portal..."
+msgstr "Si tiene un portal de transparencia en infraestructura existente..."
+
+#: ../../docs/projects/index.md:82
+msgid "**... you can add an OC4IDS export option to your system.**"
+msgstr "**... puede añadir una opción de exportación OC4IDS a su sistema.**"
+
+#: ../../docs/projects/index.md:84 ../../docs/projects/index.md:102
+msgid "**Why?**"
+msgstr "**¿Por qué?**"
+
+#: ../../docs/projects/index.md:86
+msgid ""
+"So that your project information can be compared with information from "
+"others, and to support the development of common tools for analysis of "
+"infrastructure project information. There are already many tools that work "
+"with contracting process data in OCDS format."
+msgstr ""
+"Para que su información de proyecto pueda ser comparada con información de "
+"otros, y para apoyar el desarrollo de herramientas comunes para el análisis "
+"de información de proyectos de infraestructura. Ya existen varias "
+"herramientas que trabajan con datos de procesos de contratación en formato "
+"OCDS."
+
+#: ../../docs/projects/index.md:1
+msgid "Step by step"
+msgstr "Paso a paso"
+
+#: ../../None:1
+msgid ""
+"Refer to the guidance on [publishing data from an infrastructure "
+"transparency portal](../guidance/publishing) for a step by step guide."
+msgstr ""
+"Consulte la orientación de [publicando datos desde un portal de "
+"transparencia en infraestructura](../guidance/publishing) para una guía paso"
+" a paso."
+
+#: ../../docs/projects/index.md:98
+msgid "If you are designing a new infrastructure transparency portal..."
+msgstr ""
+"Si está diseñando un nuevo portal de transparencia en infraestructura..."
+
+#: ../../docs/projects/index.md:100
+msgid "**... OC4IDS can be used by structure your data collection.**"
+msgstr "**... OC4IDS puede usarse para estructurar su recolección de datos.**"
+
+#: ../../docs/projects/index.md:104
+msgid ""
+"The specification has been designed to help you collect well structured "
+"data, comparable across contexts, and with all the fields needed to make "
+"sure the data is clear and unambiguous. It has been design to integrate with"
+" existing open contracting data sources, but to also work in cases where "
+"structured open contracting is not available."
+msgstr ""
+"La especificación ha sido diseñada para ayudarte a recolectar datos bien "
+"estructurados, comparables a través de distintos contextos, y con todos los "
+"campos necesarios para asegurar que los datos son claros e inequívocos. Ha "
+"sido diseñada para integrarse con fuentes de datos de contrataciones "
+"abiertas existentes, pero también para trabajar en casos donde datos "
+"estructurados de contrataciones abiertas no están disponibles."
+
+#: ../../docs/projects/index.md:106
+msgid ""
+"Some of the data structures, such as the organization identifier structure, "
+"may require additional data collection, but if populated with data, allow "
+"connections to be made between project data, company registers and "
+"beneficial ownership information."
+msgstr ""
+"Algunas de las estructuras de datos, tales como la estructura de "
+"identificador de organización, puede requerir la recolección de datos "
+"adicionales, pero cuando son llenados, permite hacer conexiones entre datos "
+"de proyecto, registros de compañías e información de beneficiarios finales."
+
+#: ../../docs/projects/index.md:1
+msgid "Things to consider"
+msgstr "Puntos a considerar"
+
+#: ../../None:1
+msgid ""
+"Whilst the schema can be used directly to build a data entry form, user "
+"interfaces should always be designed around user needs."
+msgstr ""
+"Aunque el esquema puede ser usado directamente para construir un formulario "
+"de entrada de datos, las interfaces de usuario deberían siempre ser "
+"diseñadas alrededor de las necesidades del usuario."
+
+#: ../../None:3
+msgid ""
+"Data can be stored directly in the JSON structure described by the schema of"
+" the specification **or** it can be stored in custom data structures, and "
+"only converted to the specification's structure when importing or exporting "
+"data."
+msgstr ""
+"Los datos pueden ser almacenados directamente en la estructura JSON descrita"
+" por la especificación del esquema **o** puede ser almacenados en "
+"estructuras de datos personalizadas, y convertidas a la estructura de la "
+"especificación sólo cuando se importan o exportan datos."
+
+#: ../../docs/projects/index.md:119
+msgid "If you are designing other data collection tools..."
+msgstr "Si está diseñando otras herramientas de recolección de datos..."
+
+#: ../../docs/projects/index.md:121
+msgid ""
+"... OC4IDS provides definitions and codelists that can be used to collect "
+"consistent data."
+msgstr ""
+"... OC4IDS provee definiciones y listas de códigos que pueden ser usados "
+"para recolectar datos consistentes."
+
+#: ../../docs/projects/index.md:123
+msgid ""
+"Consult the [specification reference for definitions](../reference/index)."
+msgstr ""
+"Consulte la [referencia de especificación para "
+"definiciones](../reference/index)."

--- a/locale/es/LC_MESSAGES/reference/browser.po
+++ b/locale/es/LC_MESSAGES/reference/browser.po
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2019\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/browser.md:1
+msgid "Schema browser"
+msgstr "Navegador del Esquema"
+
+#: ../../docs/reference/browser.md:3
+msgid "The OC4IDS schema can be explored using the browser below."
+msgstr ""
+"Puede explorar el esquema OC4IDS usando el navegador ubicado más abajo."
+
+#: ../../docs/reference/browser.md:5
+msgid ""
+"Click on schema elements to expand the tree, or use the '+' icon to expand "
+"all elements. Use { } to view the underlying schema for any section. "
+"Required fields are indicated in **bold**."
+msgstr ""
+"Haga clic en los elementos del esquema para expandir el árbol, o use el "
+"ícono '+' para expandir todos los elementos. Use {} para visualizar el "
+"esquema subyacente para cada sección. Los campos requeridos están resaltados"
+" en **negrita**."

--- a/locale/es/LC_MESSAGES/reference/changelog.po
+++ b/locale/es/LC_MESSAGES/reference/changelog.po
@@ -1,0 +1,708 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2020-05-13 23:49+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/changelog.md:1
+msgid "Changelog"
+msgstr "Registro de cambios"
+
+#: ../../docs/reference/changelog.md:3
+msgid "[0.9.2] - 2019-10-28"
+msgstr "[0.9.2] - 2019-10-28"
+
+#: ../../docs/reference/changelog.md:5
+msgid "Documentation"
+msgstr "Documentación"
+
+#: ../../docs/reference/changelog.md:7
+msgid ""
+"[#96](https://github.com/open-contracting/infrastructure/issues/96) - add "
+"guidance on providing project identifiers in OCDS data."
+msgstr ""
+"[#96](https://github.com/open-contracting/infrastructure/issues/96) - añadir"
+" orientación sobre cómo proveer identificadores de proyecto en datos OCDS."
+
+#: ../../docs/reference/changelog.md:8
+msgid ""
+"[#124](https://github.com/open-contracting/infrastructure/issues/124) - "
+"clarify guidance on project identifier prefixes."
+msgstr ""
+"[#124](https://github.com/open-contracting/infrastructure/issues/124) - "
+"aclarar orientación sobre prefijos de identificadores de proyecto."
+
+#: ../../docs/reference/changelog.md:9
+msgid ""
+"[#131](https://github.com/open-contracting/infrastructure/issues/131) - "
+"replace 'owner' with 'publicAuthority' in mapping."
+msgstr ""
+"[#131](https://github.com/open-contracting/infrastructure/issues/131) - "
+"reemplazar 'owner' con 'publicAuthority' en mapeo."
+
+#: ../../docs/reference/changelog.md:10
+msgid ""
+"[#133](https://github.com/open-contracting/infrastructure/issues/133) - "
+"improve clarity of 'what is a project' in getting started section"
+msgstr ""
+"[#133](https://github.com/open-contracting/infrastructure/issues/133) - "
+"mejorar la claridad en 'qué es un proyecto' en la sección de 'Para empezar'"
+
+#: ../../docs/reference/changelog.md:11
+msgid ""
+"[#136](https://github.com/open-contracting/infrastructure/issues/136) - add "
+"project identifier prefix to example file."
+msgstr ""
+"[#136](https://github.com/open-contracting/infrastructure/issues/136) - "
+"añadir prefijo de identificador de proyecto en archivo de ejemplo."
+
+#: ../../docs/reference/changelog.md:12
+msgid ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - "
+"update worked example page to describe project package, use non-normative "
+"keywords, and edit for clarity."
+msgstr ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - "
+"actualizar la página de ejemplo práctico para describir el paquete de "
+"proyectos, usar palabras clave no normativas, y ediciones para mayor "
+"claridad."
+
+#: ../../docs/reference/changelog.md:13
+msgid ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - add "
+"data user guide page."
+msgstr ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - "
+"añadir página de orientación para usuarios de datos."
+
+#: ../../docs/reference/changelog.md:14
+msgid ""
+"[#145](https://github.com/open-contracting/infrastructure/issues/145) - re-"
+"order codelist reference page, refer to OCDS and extension documentation for"
+" codelists that are shared"
+msgstr ""
+"[#145](https://github.com/open-contracting/infrastructure/issues/145) - "
+"reordenar la página de referencia de listas de códigos, referirse a "
+"documentación de OCDS y extensiones para listas de código comunes"
+
+#: ../../docs/reference/changelog.md:15
+msgid ""
+"[#146](https://github.com/open-contracting/infrastructure/issues/146) - add "
+"'publicAuthority' role to example file."
+msgstr ""
+"[#146](https://github.com/open-contracting/infrastructure/issues/146) - "
+"añadir el rol de 'publicAuthority' a archivo de ejemplo."
+
+#: ../../docs/reference/changelog.md:16
+msgid ""
+"[#218](https://github.com/open-contracting/infrastructure/pull/218) - add "
+"link to CoST guidance note on OGP commitments"
+msgstr ""
+"[#218](https://github.com/open-contracting/infrastructure/pull/218) - añadir"
+" un enlace a la nota de orientación de CoST sobre compromisos OGP"
+
+#: ../../docs/reference/changelog.md:17
+msgid ""
+"[#211](https://github.com/open-contracting/infrastructure/issues/211) - "
+"update description of 'publicAuthority' role"
+msgstr ""
+"[#211](https://github.com/open-contracting/infrastructure/issues/211) - "
+"actualizar la descripción del rol 'publicAuthority'"
+
+#: ../../docs/reference/changelog.md:19
+msgid "Schema"
+msgstr "Esquema"
+
+#: ../../docs/reference/changelog.md:21
+msgid "Project package schema"
+msgstr "Esquema de paquete de proyectos"
+
+#: ../../docs/reference/changelog.md:23
+msgid ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - "
+"update URL in `publicationPolicy` description to reference the data user "
+"guide page."
+msgstr ""
+"[#143](https://github.com/open-contracting/infrastructure/issues/143) - "
+"actualizar la URL en la descripción de `publicationPolicy` para referenciar "
+"a la página de orientación para usuarios de datos."
+
+#: ../../docs/reference/changelog.md:25
+msgid "OC4IDS project schema"
+msgstr "Esquema de proyecto OC4IDS"
+
+#: ../../docs/reference/changelog.md:27
+msgid ""
+"[#127](https://github.com/open-contracting/infrastructure/issues/127) - "
+"remove the requirement that linked OCDS releases must be provided in release"
+" packages containing only one release. Remove recommendation that OCDS "
+"releases are cached from schema and add guidance on caching releases from "
+"unreliable sources to implementation guidance"
+msgstr ""
+"[#127](https://github.com/open-contracting/infrastructure/issues/127) - "
+"eliminar el requerimiento de que los releases OCDS enlazados deben ser "
+"proveídos en un paquete de release que contiene un release solamente. "
+"Eliminar recomendación de almacenar releases OCDS en caché de la sección de "
+"Esquema y añadir orientación sobre almacenar releases en caché en la Guía de"
+" implementación."
+
+#: ../../docs/reference/changelog.md:28
+msgid ""
+"[#132](https://github.com/open-contracting/infrastructure/issues/132) - add "
+"a publicAuthority organization reference field"
+msgstr ""
+"[#132](https://github.com/open-contracting/infrastructure/issues/132) - "
+"agregar un campo de referencia a organización para publicAuthority"
+
+#: ../../docs/reference/changelog.md:29
+msgid ""
+"[#139](https://github.com/open-contracting/infrastructure/issues/139) - "
+"update properties of fields in common with OCDS to version "
+"[1.1.4](https://standard.open-contracting.org/1.1/en/schema/changelog/#id1)"
+msgstr ""
+"[#139](https://github.com/open-contracting/infrastructure/issues/139) - "
+"actualizar las propiedades de campos en común con OCDS a la versión "
+"[1.1.4](https://standard.open-contracting.org/1.1/en/schema/changelog/#id1)"
+
+#: ../../docs/reference/changelog.md:30
+msgid ""
+"[#140](https://github.com/open-contracting/infrastructure/issues/140) - "
+"update the description of `project/period` to clarify that this field should"
+" be used to provide the planned start and end dates during the preparation "
+"phase, for comparison with the actual completion date for the project."
+msgstr ""
+"[#140](https://github.com/open-contracting/infrastructure/issues/140) - "
+"actualizar la descripción de `project/period` para aclarar que este campo "
+"debería ser usado para proveer las fechas de inicio y fin planeadas durante "
+"la etapa de preparación, para su comparación con la fecha de finalización "
+"real del proyecto."
+
+#: ../../docs/reference/changelog.md:31
+msgid ""
+"[#141](https://github.com/open-contracting/infrastructure/issues/141) - "
+"clarify that `contractingProcesses/summary/description` is for the "
+"contract's *initial* scope of work"
+msgstr ""
+"[#141](https://github.com/open-contracting/infrastructure/issues/141) - "
+"aclarar que `contractingProcesses/summary/description` es para el alcance de"
+" trabajo *inicial* del contrato"
+
+#: ../../docs/reference/changelog.md:32
+msgid ""
+"[#141](https://github.com/open-contracting/infrastructure/issues/141) - "
+"remove incorrect guidance about other fields from "
+"`contractingProcesses/summary/modifications`"
+msgstr ""
+"[#141](https://github.com/open-contracting/infrastructure/issues/141) - "
+"eliminar orientación incorrecta sobre otros campos en "
+"`contractingProcesses/summary/modifications`"
+
+#: ../../docs/reference/changelog.md:33
+msgid ""
+"[#153](https://github.com/open-contracting/infrastructure/issues/153) - add "
+"project/relatedProjects array"
+msgstr ""
+"[#153](https://github.com/open-contracting/infrastructure/issues/153) - "
+"añadir array de project/relatedProjects"
+
+#: ../../docs/reference/changelog.md:34
+msgid ""
+"[#154](https://github.com/open-contracting/infrastructure/issues/154) - add "
+"`.requestDate` field to `project/budget` to record the date of the budget "
+"request for the project"
+msgstr ""
+"[#154](https://github.com/open-contracting/infrastructure/issues/154) - "
+"añadir el campo `.requestDate` a `project/budget` para registrar la fecha de"
+" pedido del presupuesto para el proyecto"
+
+#: ../../docs/reference/changelog.md:35
+msgid ""
+"[#156](https://github.com/open-contracting/infrastructure/issues/156) - fix "
+"the description of `completion/endDateDetails` to refer to the end date of "
+"the *project*, not that of the *contract*"
+msgstr ""
+"[#156](https://github.com/open-contracting/infrastructure/issues/156) - "
+"corregir la descripción de `completion/endDateDetails` para referirse a la "
+"fecha de finalización del *proyecto*, no la del *contrato*"
+
+#: ../../docs/reference/changelog.md:36
+msgid ""
+"[#157](https://github.com/open-contracting/infrastructure/issues/157) - fix "
+"spelling and grammar issues"
+msgstr ""
+"[#157](https://github.com/open-contracting/infrastructure/issues/157) - "
+"corrección de problemas de ortografía y gramática"
+
+#: ../../docs/reference/changelog.md:37
+msgid ""
+"[#158](https://github.com/open-contracting/infrastructure/issues/158) - make"
+" `contractingProcesses/releases/tag` an array, not a string (bugfix)"
+msgstr ""
+"[#158](https://github.com/open-contracting/infrastructure/issues/158) - "
+"hacer que `contractingProcesses/releases/tag` sea un array y no una cadena "
+"de texto (bugfix)"
+
+#: ../../docs/reference/changelog.md:38
+msgid ""
+"[#160](https://github.com/open-contracting/infrastructure/issues/160) - "
+"describe the components of `project/id`, and link to guidance"
+msgstr ""
+"[#160](https://github.com/open-contracting/infrastructure/issues/160) - "
+"describir los componentes de `project/id`, y añadir enlace a la guía"
+
+#: ../../docs/reference/changelog.md:39
+msgid ""
+"[#161](https://github.com/open-contracting/infrastructure/issues/161) - "
+"removed `contractingProcesses/summary/ocid` because it duplicates "
+"`contractingProcesses/id`"
+msgstr ""
+"[#161](https://github.com/open-contracting/infrastructure/issues/161) - "
+"eliminar `contractingProcesses/summary/ocid` porque es un duplicado de "
+"`contractingProcesses/id`"
+
+#: ../../docs/reference/changelog.md:41
+msgid "Codelists"
+msgstr "Listas de códigos"
+
+#: ../../docs/reference/changelog.md:43
+msgid ""
+"[#139](https://github.com/open-contracting/infrastructure/issues/139) - "
+"update codelists in common with OCDS to version [1.1.4](https://standard"
+".open-contracting.org/1.1/en/schema/changelog/#id1)"
+msgstr ""
+"[#139](https://github.com/open-contracting/infrastructure/issues/139) - "
+"actualizar listas de código en común con OCDS a la versión "
+"[1.1.4](https://standard.open-contracting.org/1.1/en/schema/changelog/#id1)"
+
+#: ../../docs/reference/changelog.md:44
+msgid ""
+"[#152](https://github.com/open-contracting/infrastructure/issues/152) - add "
+"'expansion' code to projectType codelist."
+msgstr ""
+"[#152](https://github.com/open-contracting/infrastructure/issues/152) - "
+"agregar el código 'expansion' a la lista de códigos projectType."
+
+#: ../../docs/reference/changelog.md:46
+msgid "[0.9.1] - 2019-06-17"
+msgstr "[0.9.1] - 2019-06-17"
+
+#: ../../docs/reference/changelog.md:48
+msgid "Changed"
+msgstr "Cambiado"
+
+#: ../../docs/reference/changelog.md:50
+msgid "Add changelog."
+msgstr "Añadir el registro de cambios."
+
+#: ../../docs/reference/changelog.md:51
+msgid "Update ocds-babel to 0.1.0."
+msgstr "Actualizar ocds-babel a 0.1.0."
+
+#: ../../docs/reference/changelog.md:53
+msgid "Fixed"
+msgstr "Corregido"
+
+#: ../../docs/reference/changelog.md:55
+msgid "Correct schema URLs in schema files."
+msgstr "Corregir URLs de esquema en los archivos de esquema."
+
+#: ../../docs/reference/changelog.md:57
+msgid "[0.9.0-beta] - 2019-03-19"
+msgstr "[0.9.0-beta] - 2019-03-19"
+
+#: ../../docs/reference/changelog.md:59
+msgid ""
+"This changelog entry indicates notable changes since the alpha-2 development"
+" release of OC4IDS, it is not intended to be a complete list of changes."
+msgstr ""
+"Esta entrada en el registro de cambios indica cambios notables desde el "
+"lanzamiento de desarrollo alfa-2 de OC4IDS, no pretende ser una lista de "
+"cambios completa."
+
+#: ../../docs/reference/changelog.md:61
+msgid ""
+"In addition to the specific changes to schema and codelists noted below:"
+msgstr ""
+"En adición a los cambios específicos al esquema y listas de códigos "
+"mencionados abajo:"
+
+#: ../../docs/reference/changelog.md:63
+msgid ""
+"Various refinements and clarifications were made to schema and codelist "
+"descriptions."
+msgstr ""
+"Refinamientos y clarificaciones varias fueron hechas a las descripciones del"
+" esquema y listas de códigos."
+
+#: ../../docs/reference/changelog.md:64
+msgid ""
+"Guidance on mapping values from OCDS was moved from the schema to the IDS "
+"and OCDS mapping section of the documentation."
+msgstr ""
+"La orientación sobre mapear valores desde OCDS fue movida del esquema a la "
+"sección de mapeo  de IDS y OCDS en la documentación."
+
+#: ../../docs/reference/changelog.md:65
+msgid "Documentation was expanded and restructured."
+msgstr "La documentación fue expandida y reestructurada."
+
+#: ../../docs/reference/changelog.md:67
+msgid "Packaging"
+msgstr "Empaquetado"
+
+#: ../../docs/reference/changelog.md:69
+msgid ""
+"Add [project package schema](https://standard.open-"
+"contracting.org/infrastructure/latest/en/reference/package/). OC4IDS data "
+"must be published as part of a project package."
+msgstr ""
+"Añadir el [esquema de paquete de proyectos](https://standard.open-"
+"contracting.org/infrastructure/latest/en/reference/package/). Los datos "
+"OC4IDS deben ser publicados como parte de un paquete de proyectos."
+
+#: ../../docs/reference/changelog.md:71
+msgid "Schema updates"
+msgstr "Actualizaciones al esquema"
+
+#: ../../docs/reference/changelog.md:73
+msgid "`sector` - use projectSector open codelist"
+msgstr "`sector` - usa la lista de códigos abierta projectSector"
+
+#: ../../docs/reference/changelog.md:74
+msgid "`ContractingProcess` - add required `id` field"
+msgstr "`ContractingProcess` - añade el campo requerido `id`"
+
+#: ../../docs/reference/changelog.md:75
+msgid "`LinkedRelease` - make `id` required"
+msgstr "`LinkedRelease` - establecer `id` como requerido"
+
+#: ../../docs/reference/changelog.md:76
+msgid "`variations` - rename to `modifications`"
+msgstr "`variations` - renombrar a `modifications`"
+
+#: ../../docs/reference/changelog.md:77
+msgid "`Location` - add required `id` field"
+msgstr "`Location` - añade el campo requerido `id`"
+
+#: ../../docs/reference/changelog.md:79
+msgid "New codelists"
+msgstr "Nuevas listas de códigos"
+
+#: ../../docs/reference/changelog.md:81
+msgid "`projectSector` codelist - add codelist for project sector"
+msgstr ""
+"Lista de códigos `projectSector` - añade una lista de códigos para el sector"
+" del proyecto"
+
+#: ../../docs/reference/changelog.md:83
+msgid "Codelist updates"
+msgstr "Actualizaciones en listas de códigos"
+
+#: ../../docs/reference/changelog.md:85
+msgid "projectStatus codelist - replace 'construction' with 'implementation'"
+msgstr ""
+"Lista de códigos projectStatus - reemplazar 'construction' con "
+"'implementation'"
+
+#: ../../docs/reference/changelog.md:86
+msgid "variationType codelist - rename to modificationType"
+msgstr "Lista de códigos variationType - renombrar a modificationType"
+
+#: ../../docs/reference/changelog.md:87
+msgid "partyRole codelist - add OC4IDS codes mentioned in schema and mapping:"
+msgstr ""
+"Lista de códigos partyRole- añadir códigos OC4IDS mencionados en el esquema "
+"y mapeo:"
+
+#: ../../docs/reference/changelog.md:88
+msgid "funder"
+msgstr "funder"
+
+#: ../../docs/reference/changelog.md:89
+msgid "administrativeEntity"
+msgstr "administrativeEntity"
+
+#: ../../docs/reference/changelog.md:90
+msgid "partyRole codelist - add codes from OCDS partyRole codelist:"
+msgstr ""
+"Lista de códigos partyRole - añadir códigos de la lista de códigos OCDS "
+"partyRole:"
+
+#: ../../docs/reference/changelog.md:91
+msgid "buyer"
+msgstr "buyer"
+
+#: ../../docs/reference/changelog.md:92
+msgid "procuringEntity"
+msgstr "procuringEntity"
+
+#: ../../docs/reference/changelog.md:93
+msgid "supplier"
+msgstr "supplier"
+
+#: ../../docs/reference/changelog.md:94
+msgid "tenderer"
+msgstr "tenderer"
+
+#: ../../docs/reference/changelog.md:95
+msgid "partyRole codelist - remove PPP-specific codes:"
+msgstr "Lista de códigos partyRole - eliminar códigos específicos de PPP:"
+
+#: ../../docs/reference/changelog.md:96
+msgid "bidder"
+msgstr "bidder"
+
+#: ../../docs/reference/changelog.md:97
+msgid "qualifiedBidder"
+msgstr "qualifiedBidder"
+
+#: ../../docs/reference/changelog.md:98
+msgid "preferredBidder"
+msgstr "preferredBidder"
+
+#: ../../docs/reference/changelog.md:99
+msgid "privateParty"
+msgstr "privateParty"
+
+#: ../../docs/reference/changelog.md:100
+msgid "leadBank"
+msgstr "leadBank"
+
+#: ../../docs/reference/changelog.md:101
+msgid "lender"
+msgstr "lender"
+
+#: ../../docs/reference/changelog.md:102
+msgid "equityInvestor"
+msgstr "equityInvestor"
+
+#: ../../docs/reference/changelog.md:103
+msgid "consortiaMember"
+msgstr "consortiaMember"
+
+#: ../../docs/reference/changelog.md:104
+msgid "interestedParty"
+msgstr "interestedParty"
+
+#: ../../docs/reference/changelog.md:105
+msgid "grantor"
+msgstr "grantor"
+
+#: ../../docs/reference/changelog.md:106
+msgid "disqualifiedBidder"
+msgstr "disqualifiedBidder"
+
+#: ../../docs/reference/changelog.md:107
+msgid "socialWitness"
+msgstr "socialWitness"
+
+#: ../../docs/reference/changelog.md:108
+msgid "otherWitness"
+msgstr "otherWitness"
+
+#: ../../docs/reference/changelog.md:109
+msgid "notary"
+msgstr "notary"
+
+#: ../../docs/reference/changelog.md:110
+msgid "documentType codelist - remove PPP-specific codes:"
+msgstr "Lista de códigos documentType - eliminar códigos específicos de PPP:"
+
+#: ../../docs/reference/changelog.md:111
+msgid "financeAdditionality"
+msgstr "financeAdditionality"
+
+#: ../../docs/reference/changelog.md:112
+msgid "pppModeRationale"
+msgstr "pppModeRationale"
+
+#: ../../docs/reference/changelog.md:113
+msgid "riskComparison"
+msgstr "riskComparison"
+
+#: ../../docs/reference/changelog.md:114
+msgid "discountRate"
+msgstr "discountRate"
+
+#: ../../docs/reference/changelog.md:115
+msgid "equityTransferCaps"
+msgstr "equityTransferCaps"
+
+#: ../../docs/reference/changelog.md:116
+msgid "financeArrangements"
+msgstr "financeArrangements"
+
+#: ../../docs/reference/changelog.md:117
+msgid "guaranteeReports"
+msgstr "guaranteeReports"
+
+#: ../../docs/reference/changelog.md:118
+msgid "grants"
+msgstr "grants"
+
+#: ../../docs/reference/changelog.md:119
+msgid "servicePayments"
+msgstr "servicePayments"
+
+#: ../../docs/reference/changelog.md:120
+msgid "landTransfer"
+msgstr "landTransfer"
+
+#: ../../docs/reference/changelog.md:121
+msgid "assetTransfer"
+msgstr "assetTransfer"
+
+#: ../../docs/reference/changelog.md:122
+msgid "revenueShare"
+msgstr "revenueShare"
+
+#: ../../docs/reference/changelog.md:123
+msgid "otherGovernmentSupport"
+msgstr "otherGovernmentSupport"
+
+#: ../../docs/reference/changelog.md:124
+msgid "tariffMethod"
+msgstr "tariffMethod"
+
+#: ../../docs/reference/changelog.md:125
+msgid "tariffReview"
+msgstr "tariffReview"
+
+#: ../../docs/reference/changelog.md:126
+msgid "tariffs"
+msgstr "tariffs"
+
+#: ../../docs/reference/changelog.md:127
+msgid "tariffIllustration"
+msgstr "tariffIllustration"
+
+#: ../../docs/reference/changelog.md:128
+msgid "handover"
+msgstr "handover"
+
+#: ../../docs/reference/changelog.md:129
+msgid "financialStatement"
+msgstr "financialStatement"
+
+#: ../../docs/reference/changelog.md:130
+msgid "documentType codelist - add codes from OCDS documentType codelist:"
+msgstr ""
+"Lista de códigos documentType - añadir códigos de la lista de códigos OCDS "
+"documentType:"
+
+#: ../../docs/reference/changelog.md:131
+msgid "contractNotice"
+msgstr "contractNotice"
+
+#: ../../docs/reference/changelog.md:132
+msgid "completionCertificate"
+msgstr "completionCertificate"
+
+#: ../../docs/reference/changelog.md:133
+msgid "procurementPlan"
+msgstr "procurementPlan"
+
+#: ../../docs/reference/changelog.md:134
+msgid "biddingDocuments"
+msgstr "biddingDocuments"
+
+#: ../../docs/reference/changelog.md:135
+msgid "contractArrangements"
+msgstr "contractArrangements"
+
+#: ../../docs/reference/changelog.md:136
+msgid "physicalProgressReport"
+msgstr "physicalProgressReport"
+
+#: ../../docs/reference/changelog.md:137
+msgid "financialProgressReport"
+msgstr "financialProgressReport"
+
+#: ../../docs/reference/changelog.md:138
+msgid "hearingNotice"
+msgstr "hearingNotice"
+
+#: ../../docs/reference/changelog.md:139
+msgid "marketStudies"
+msgstr "marketStudies"
+
+#: ../../docs/reference/changelog.md:140
+msgid "eligibilityCriteria"
+msgstr "eligibilityCriteria"
+
+#: ../../docs/reference/changelog.md:141
+msgid "clarifications"
+msgstr "clarifications"
+
+#: ../../docs/reference/changelog.md:142
+msgid "assetAndLiabilityAssessment"
+msgstr "assetAndLiabilityAssessment"
+
+#: ../../docs/reference/changelog.md:143
+msgid "winningBid"
+msgstr "winningBid"
+
+#: ../../docs/reference/changelog.md:144
+msgid "complaints"
+msgstr "complaints"
+
+#: ../../docs/reference/changelog.md:145
+msgid "contractAnnexe"
+msgstr "contractAnnexe"
+
+#: ../../docs/reference/changelog.md:146
+msgid "subContract"
+msgstr "subContract"
+
+#: ../../docs/reference/changelog.md:147
+msgid "projectPlan"
+msgstr "projectPlan"
+
+#: ../../docs/reference/changelog.md:148
+msgid "billOfQuantity"
+msgstr "billOfQuantity"
+
+#: ../../docs/reference/changelog.md:149
+msgid "bidders"
+msgstr "bidders"
+
+#: ../../docs/reference/changelog.md:150
+msgid "conflictOfInterest"
+msgstr "conflictOfInterest"
+
+#: ../../docs/reference/changelog.md:151
+msgid "debarments"
+msgstr "debarments"
+
+#: ../../docs/reference/changelog.md:152
+msgid "illustration"
+msgstr "illustration"
+
+#: ../../docs/reference/changelog.md:153
+msgid "submissionDocuments"
+msgstr "submissionDocuments"
+
+#: ../../docs/reference/changelog.md:154
+msgid "contractSummary"
+msgstr "contractSummary"
+
+#: ../../docs/reference/changelog.md:155
+msgid "cancellationDetails"
+msgstr "cancellationDetails"

--- a/locale/es/LC_MESSAGES/reference/codelists.po
+++ b/locale/es/LC_MESSAGES/reference/codelists.po
@@ -1,0 +1,1997 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/codelists.md:1
+msgid "Codelist reference"
+msgstr "Referencia de listas de código"
+
+#: ../../docs/reference/codelists.md:3
+msgid ""
+"Some schema fields refer to codelists, to limit and standardize the possible"
+" values of the fields, in order to promote data interoperability."
+msgstr ""
+"Algunos campos del esquema utilizan listas de códigos para limitar y "
+"estandarizar los posibles valores de los campos, con el fin de promover la "
+"interoperabilidad de los datos."
+
+#: ../../docs/reference/codelists.md:5
+msgid ""
+"Codelists can either be open or closed. **Closed codelists** are intended to"
+" be comprehensive; for example, the [currency](#currency) codelist covers "
+"all currencies in the world. **Open codelists** are intended to be "
+"representative, but not comprehensive."
+msgstr ""
+"Las listas de códigos pueden ser cerradas o abiertas. Las **listas de "
+"códigos cerradas** están pensadas para ser globales; por ejemplo, la lista "
+"de códigos de [moneda](#currency) cubre todas las monedas en el mundo. Las "
+"**listas de códigos abiertas** están pensadas para ser representativas, pero"
+" no globales."
+
+#: ../../docs/reference/codelists.md:7
+msgid ""
+"Publishers must use the codes in the codelists, unless no code is "
+"appropriate. If no code is appropriate and the codelist is **open**, then a "
+"publisher may use a new code outside those in the codelist. If no code is "
+"appropriate and the codelist is **closed**, then a publisher should instead "
+"create an issue in the [OC4IDS GitHub repository](https://github.com/open-"
+"contracting/infrastructure/issues)."
+msgstr ""
+"Los publicadores deben usar los códigos contenidos en las listas de códigos,"
+" a menos que no exista un código apropiado. Si no existe un código apropiado"
+" y la lista es **abierta**, entonces el publicador puede usar un nuevo "
+"código fuera de la lista. Si no existe un código apropiado y la lista es "
+"**cerrada**, entonces el publicador debe crear un issue en el [repositorio "
+"de OC4IDS en GitHub](https://github.com/open-"
+"contracting/infrastructure/issues)."
+
+#: ../../docs/reference/codelists.md:1
+msgid "Extending open codelists"
+msgstr "Extendiendo listas de códigos abiertas"
+
+#: ../../None:1
+msgid ""
+"If you use new codes outside those in an open codelist, please create an "
+"issue in the [OC4IDS GitHub repository](https://github.com/open-"
+"contracting/infrastructure/issues), so that the codes can be considered for "
+"inclusion in the codelist."
+msgstr ""
+"Si usas códigos nuevos fuera de una lista de códigos abierta, por favor crea"
+" un issue en el [repositorio de OC4IDS en GitHub](https://github.com/open-"
+"contracting/infrastructure/issues), para que estos códigos puedan ser "
+"considerados para su inclusión en la lista de códigos."
+
+#: ../../docs/reference/codelists.md:19
+msgid ""
+"For more information on open and closed codelists, refer to the Open "
+"Contracting Data Standard [codelists documentation](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/)."
+msgstr ""
+"Para más información sobre listas cerradas y abiertas, consultar la "
+"[documentación de listas de códigos](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/) del Estándar de Datos de "
+"Contrataciones Abiertas."
+
+#: ../../docs/reference/codelists.md:21
+msgid "OCDS codelists"
+msgstr "Listas de código OCDS"
+
+#: ../../docs/reference/codelists.md:23
+msgid ""
+"OC4IDS reuses some codelists from the Open Contracting Data Standard and its"
+" extensions:"
+msgstr ""
+"OC4IDS reutiliza algunas listas de códigos del Estándar de Datos de "
+"Contrataciones Abiertas y sus extensiones:"
+
+#: ../../docs/reference/codelists.md:25
+msgid ""
+"[Currency](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#currency)"
+msgstr ""
+"[Moneda](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/#currency)"
+
+#: ../../docs/reference/codelists.md:26
+msgid ""
+"[Geometry type](https://extensions.open-"
+"contracting.org/en/extensions/location/master/codelists/#geometryType.csv)"
+msgstr ""
+"[Tipo de Geometría](https://extensions.open-"
+"contracting.org/es/extensions/location/master/codelists/#geometryType.csv)"
+
+#: ../../docs/reference/codelists.md:27
+msgid ""
+"[Location gazetteers](https://extensions.open-"
+"contracting.org/en/extensions/location/master/codelists/#locationGazetteers.csv)"
+msgstr ""
+"[Diccionarios geográficos de ubicación](https://extensions.open-"
+"contracting.org/es/extensions/location/master/codelists/#locationGazetteers.csv)"
+
+#: ../../docs/reference/codelists.md:28
+msgid ""
+"[Method](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#method)"
+msgstr ""
+"[Método](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/#method)"
+
+#: ../../docs/reference/codelists.md:29
+msgid ""
+"[Organization identifier scheme](https://standard.open-"
+"contracting.org/1.1/en/schema/codelists/#organization-identifier-scheme)"
+msgstr ""
+"[Esquema de identificación de organizaciones](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/#organization-identifier-scheme)"
+
+#: ../../docs/reference/codelists.md:30
+msgid ""
+"[Release tag](https://standard.open-contracting.org/1.1/en/schema/codelists"
+"/#release-tag)"
+msgstr ""
+"[Etiqueta de release](https://standard.open-"
+"contracting.org/1.1/es/schema/codelists/#release-tag)"
+
+#: ../../docs/reference/codelists.md:32
+msgid "Closed codelists"
+msgstr "Listas de códigos cerradas"
+
+#: ../../docs/reference/codelists.md:34
+msgid "ContractingProcessStatus"
+msgstr "Estado del proceso de contratación"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+#: ../current_lang/codelists/contractNature.csv:1
+#: ../current_lang/codelists/projectStatus.csv:1
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/modificationType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/projectSector.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid "Code"
+msgstr "Código"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+#: ../current_lang/codelists/contractNature.csv:1
+#: ../current_lang/codelists/projectStatus.csv:1
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/modificationType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/projectSector.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid "Title"
+msgstr "Título"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+#: ../current_lang/codelists/contractNature.csv:1
+#: ../current_lang/codelists/projectStatus.csv:1
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/modificationType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/projectSector.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid "Description"
+msgstr "Descripción"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "Business Logic"
+msgstr "Lógica del Negocio"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "pre-award"
+msgstr "Pre-adjudicación"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "Pre-award"
+msgstr "Pre-adjudicación"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "No contract has yet been awarded, and the process has not ended."
+msgstr ""
+"No se ha adjudicado ningún contrato aún, y el proceso no ha terminado."
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid ""
+"tender.status is not 'cancelled', 'unsuccessful' or 'withdrawn', and one of:"
+" There are no awards or contracts; All Award.status and Contract.status are "
+"'pending'; All award dates (whether expressed as award.date or "
+"tender.awardPeriod) are in the future."
+msgstr ""
+"tender.status no es 'cancelled', 'unsuccessful' o 'withdrawn', y se cumple "
+"uno de los siguientes: No hay adjudicaciones ni contratos; Todos los "
+"award.status y contract.status son 'pending'; Todas las fechas de "
+"adjudicación (expresadas en award.date o tender.awardPeriod) son en el "
+"futuro."
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "active"
+msgstr "active"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "Active"
+msgstr "Activo"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "A contract was awarded, but not all contracts have ended."
+msgstr ""
+"Un contrato fue adjudicado, pero no todos los contratos han finalizado."
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid ""
+"One of: There is at least one Contract.status of 'active'; At least one "
+"contract period (whether expressed as Contract.period, Award.contractPeriod "
+"or tender.contractPeriod) includes the present date."
+msgstr ""
+"Se cumple uno de los siguientes criterios: Hay al menos un Contract.status "
+"con valor 'active'; Al menos un periodo de contrato (ya sea Contract.period,"
+" Award.contractPeriod o tender.contractPeriod) incluye la fecha presente."
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "closed"
+msgstr "closed"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid "Closed"
+msgstr "Cerrado"
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid ""
+"The process ended with no contract being awarded, or all contracts have "
+"ended."
+msgstr ""
+"El proceso terminó sin ningún contrato adjudicado, o todos los contratos han"
+" finalizado."
+
+#: ../current_lang/codelists/contractingProcessStatus.csv:1
+msgid ""
+"One of: tender.status is 'cancelled', 'unsuccessful' or 'withdrawn'; There "
+"is at least one award, and all Award.status are 'cancelled' or "
+"'unsuccessful'; There is at least one contract, and all Contract.status are "
+"'terminated' or 'cancelled'; The endDate of all contract periods are in the "
+"past."
+msgstr ""
+"Se cumple uno de: tender.status es 'cancelled', 'unsuccessful' o "
+"'withdrawn'; Hay al menos una adjudicación, y todos los Award.status son  "
+"'cancelled' o 'unsuccessful'; Hay al menos un contrato, y todos los "
+"Contract.status son 'terminated' o 'cancelled'; Los endDate de todos los "
+"períodos de contrato están en el pasado."
+
+#: ../../docs/reference/codelists.md:45
+msgid "ContractNature"
+msgstr "ContractNature"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid "design"
+msgstr "design"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid "Design"
+msgstr "Diseño"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid "This contracting process relates to design of the project."
+msgstr ""
+"Este proceso de contratación está relacionado con el diseño del proyecto."
+
+#: ../current_lang/codelists/contractNature.csv:1
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "construction"
+msgstr "construction"
+
+#: ../current_lang/codelists/contractNature.csv:1
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "Construction"
+msgstr "Construcción"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid ""
+"This contracting process relates to build or construction work for the "
+"project."
+msgstr ""
+"Este proceso de contratación está relacionado a trabajos de construcción "
+"para el proyecto."
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid "supervision"
+msgstr "supervision"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid "Supervision"
+msgstr "Supervisión"
+
+#: ../current_lang/codelists/contractNature.csv:1
+msgid ""
+"This contracting process relates to supervision or monitoring of the "
+"project."
+msgstr ""
+"Este proceso de contratación está relacionado a la supervisión o monitoreo "
+"del proyecto."
+
+#: ../../docs/reference/codelists.md:56
+msgid "ProjectStatus"
+msgstr "ProjectStatus"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "identification"
+msgstr "identification"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Identification"
+msgstr "Identificación"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid ""
+"Identification refers to the decision to develop a project within the budget"
+" and programme of a project owner (the public entity responsible for "
+"executing the budget)."
+msgstr ""
+"Identificación se refiere a la primera etapa de ejecución de un proyecto "
+"dentro del presupuesto y programa del dueño del proyecto (la entidad pública"
+" responsable de ejecutar el presupuesto)."
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "preparation"
+msgstr "preparation"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Preparation"
+msgstr "Preparación"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid ""
+"Preparation covers the feasibility study, environmental and social impact "
+"assessment, general scoping of the project, establishing the packaging and "
+"procurement strategy, preliminary statutory requirements on environmental "
+"and land impacts, and the resulting budget authorization."
+msgstr ""
+"La preparación cubre el estudio de factibilidad, medioambiental y la "
+"evaluación del impacto social, alcance general del proyecto, establecer el "
+"embalaje y la estrategia de adquisiciones, requerimientos legales "
+"preliminares sobre impacto medioambiental y terrenos, y la resultante "
+"actualización del presupuesto."
+
+#: ../current_lang/codelists/projectStatus.csv:1
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "implementation"
+msgstr "implementation"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid ""
+"Implementation covers the procurement and implementation of the group of "
+"works or services (such as design and supervision) to be delivered under the"
+" project, including works or services performed by the procuring entity. "
+"This differs from the definition of 'implementation' in OCDS, which covers "
+"the implementation but not the procurement."
+msgstr ""
+"La implementación cubre la adquisición e implementación del grupo de "
+"trabajos o servicios (como el diseño y la supervisión) a ser entregados bajo"
+" el proyecto, incluyendo trabajos o servicios realizados por la entidad "
+"contratante. Esto difiere de la definición de \"implementación\" en OCDS, "
+"que cubre la implementación pero no la adquisición."
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "completion"
+msgstr "completion"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Completion"
+msgstr "Finalización"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid ""
+"Completion covers the handover of the assets and close-out activities with "
+"details of the final scope, cost, and delivery time."
+msgstr ""
+"La finalización cubre la entrega de los resultados y las actividades de "
+"cierre con detalles del alcance final, costos y tiempos de entrega."
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "completed"
+msgstr "completed"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Completed"
+msgstr "Completado"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Close-out activities were completed, and this project is inactive."
+msgstr ""
+"Las actividades de cierre han sido completadas y este proyecto está "
+"inactivo."
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "cancelled"
+msgstr "cancelled"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#: ../current_lang/codelists/projectStatus.csv:1
+msgid ""
+"This project was cancelled before close-out activities were completed, and "
+"is inactive. Cancellation can occur anytime after identification."
+msgstr ""
+"Este proyecto fue cancelado antes que las actividades de cierre fueran "
+"completadas y está inactivo. La cancelación puede ocurrir en cualquier "
+"momento luego de la identificación."
+
+#: ../../docs/reference/codelists.md:67
+msgid ""
+"Projects with a `status` of 'completed' may be displayed in a list of "
+"archived projects."
+msgstr ""
+"Proyectos con `estado` 'completed' pueden ser desplegados en una lista de "
+"proyectos archivados."
+
+#: ../../docs/reference/codelists.md:69
+msgid "ProjectType"
+msgstr "ProjectType"
+
+#: ../current_lang/codelists/projectType.csv:1
+msgid "The primary focus of this project is the construction of a new asset."
+msgstr ""
+"El foco principal de este proyecto es la contrucción de un nuevo activo."
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "rehabilitation"
+msgstr "rehabilitation"
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "Rehabilitation"
+msgstr "Rehabilitación"
+
+#: ../current_lang/codelists/projectType.csv:1
+msgid ""
+"The primary focus of this project is the rehabilitation of an existing "
+"asset."
+msgstr ""
+"El foco principal de este proyecto es la rehabilitación de un activo "
+"existente."
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "replacement"
+msgstr "replacement"
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "Replacement"
+msgstr "Reemplazo"
+
+#: ../current_lang/codelists/projectType.csv:1
+msgid ""
+"The primary focus of this project is the replacement of an existing asset."
+msgstr ""
+"El foco principal de este proyecto es el reemplazo de un activo existente."
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "expansion"
+msgstr "expansion"
+
+#: ../current_lang/codelists/projectType.csv:1
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid "Expansion"
+msgstr "Expansión"
+
+#: ../current_lang/codelists/projectType.csv:1
+msgid ""
+"The primary focus of this project is the expansion of an existing asset."
+msgstr ""
+"El enfoque primario de este proyecto es la expansión de un activo existente."
+
+#: ../../docs/reference/codelists.md:80
+msgid "Open codelists"
+msgstr "Listas de código abiertas"
+
+#: ../../docs/reference/codelists.md:82
+msgid "DocumentType"
+msgstr "DocumentType"
+
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Source"
+msgstr "Fuente"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "valueForMoneyAnalysis"
+msgstr "valueForMoneyAnalysis"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Value for money analysis"
+msgstr "Análisis de valor por dinero"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A summary of the value for money analysis carried out for the project, along"
+" with supporting figures, calculations and business case, based on projected"
+" or actual procurement outcomes."
+msgstr ""
+"Un resumen del análisis del valor por dinero realizado para el proyecto, "
+"junto con gráficos, cálculos y justificación económica de apoyo, basados en "
+"resultados de adquisiciones proyectadas o reales."
+
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+msgid "OCDS for PPPs"
+msgstr "OCDS para APP"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "technicalSpecifications"
+msgstr "technicalSpecifications"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Technical Specifications"
+msgstr "Especificaciones Técnicas"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Detailed technical information about goods or services to be provided."
+msgstr ""
+"Información técnica detallada sobre bienes o servicios a ser proveídos."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "serviceDescription"
+msgstr "serviceDescription"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Service descriptions"
+msgstr "Descripciones del servicio"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "A high-level description of the services"
+msgstr "Una descripción de alto nivel de los servicios"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "estimatedDemand"
+msgstr "estimatedDemand"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Estimated demand"
+msgstr "Demanda estimada"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A narrative describing the estimated demand to be served (annually) by the "
+"project."
+msgstr ""
+"Una narrativa describiendo la demanda estimada a ser cubierta (anualmente) "
+"por el proyecto."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractDraft"
+msgstr "contractDraft"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Contract draft"
+msgstr "Borrador de contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "A draft or pro-forma copy of the contract."
+msgstr "Un borrador o copia pro-forma del contrato."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractSigned"
+msgstr "contractSigned"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Signed Contract"
+msgstr "Contrato firmado"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A copy of the signed contract. Consider providing both machine-readable "
+"(e.g. original PDF, Word or Open Document format files), and a separate "
+"document entry for scanned-signed pages where this is required."
+msgstr ""
+"Una copia del contrato firmado. Considera proveer una versión legible por "
+"máquina (ej. PDF original, formatos de archivo Word o Open Document), y un "
+"documento separado para documentos escaneados cuando así se requiera."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "feasibilityStudy"
+msgstr "feasibilityStudy"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Feasibility study"
+msgstr "Estudio de viabilidad (factibilidad)"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of feasibility studies carried out for this contracting "
+"process, providing information on net benefits or costs of the proposed "
+"goods, works or services."
+msgstr ""
+"Documentación de estudios de viabilidad (factibilidad) llevados a cabo para "
+"este proyecto, que proveen información de beneficios netos o costos de los "
+"bienes, obras o servicios propuestos."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "environmentalImpact"
+msgstr "environmentalImpact"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Environmental Impact"
+msgstr "Impacto ambiental"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of assessments of the environmental impacts (e.g. impacts on "
+"flora, fauna & woodlands, areas of natural beauty, carbon emissions etc.) "
+"and mitigation measures (e.g. pollution control, low carbon solutions, "
+"sustainable timber etc.) for this contracting process or project."
+msgstr ""
+"Documentación de la evaluación del impacto ambiental (ej. impacto en flora, "
+"fauna y zonas boscosas, áreas de belleza natural, emisiones de carbono, "
+"etc.) y medidas de mitigación (ej. control de contaminación, soluciones "
+"bajas en carbono, fuentes sustentables de madera, etc.) para este proceso "
+"proyecto."
+
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "OC4IDS"
+msgstr "OC4IDS"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "finalAudit"
+msgstr "finalAudit"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Final Audit"
+msgstr "Auditoría final"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of a final audit carried out at the end of contract "
+"implementation."
+msgstr ""
+"Documentación de la auditoría final llevada a cabo al final de la "
+"implementación del proyecto o contrato(s)."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "tenderNotice"
+msgstr "tenderNotice"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Tender Notice"
+msgstr "Aviso de licitación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"The formal notice that gives details of a tender. This may be a link to a "
+"downloadable document, to a web page, or to an official gazette in which the"
+" notice is contained."
+msgstr ""
+"El aviso formal que brinda detalles de una licitación. Este puede ser un "
+"enlace a un documento descargable, a una página web, o a una gaceta oficial "
+"en la que el aviso está contenido."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "evaluationCommittee"
+msgstr "evaluationCommittee"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Evaluation Committee Details"
+msgstr "Detalles del comité de evaluación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Information on the constitution of the evaluation committee"
+msgstr "Información sobre la constitución del comité de evaluación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "requestForQualification"
+msgstr "requestForQualification"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Request for Qualification"
+msgstr "Pedido de calificación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"The set of documents issued by the procuring authority that constitute the "
+"basis of the qualification and potentially the pre-selection of candidates "
+"(the short list). Qualified (or short-listed candidates) will then be "
+"invited to submit a proposal (or to enter into a new phase prior to bid "
+"submission, such as a dialogue phase or interactive phase)."
+msgstr ""
+"El conjunto de documentos emitidos por la entidad contratante que "
+"constituyen la base de la calificación y potencialmente la pre-selección de "
+"candidatos (la lista corta). Los candidatos calificados serán invitados a "
+"presentar una propuesta (o a entrar a una nueva fase previa a la "
+"presentación de oferta, como una fase de diálogo o una fase interactiva)"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "evaluationCriteria"
+msgstr "evaluationCriteria"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Evaluation Criteria"
+msgstr "Criterios de evaluación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Documentation on how bids will be evaluated."
+msgstr "Documentación sobre cómo las ofertas serán evaluadas."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "minutes"
+msgstr "minutes"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Minutes"
+msgstr "Minutas"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Minutes of pre-bid meetings, or other relevant meetings."
+msgstr "Minutas de reuniones pre-oferta, u otras reuniones relevantes."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "shortlistedFirms"
+msgstr "shortlistedFirms"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Shortlisted Firms"
+msgstr "Firmas preseleccionadas"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation providing information on shortlisted firms. Structured "
+"versions of this information can be provided using the bids extension."
+msgstr ""
+"Documentación que provee información sobre firmas preseleccionadas. Se "
+"pueden proveer versiones estructuradas de esta información usando la "
+"extensión de ofertas (bids)."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "negotiationParameters"
+msgstr "negotiationParameters"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Negotiation Parameters"
+msgstr "Parámetros de negociación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A description of the parameters for negotiation with the preferred proponent"
+msgstr ""
+"Una descripción de los parámetros de negociación con el proponente "
+"preferido."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "evaluationReports"
+msgstr "evaluationReports"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Evaluation report"
+msgstr "Reportes de evaluación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation on the evaluation of the bids and the application of the "
+"evaluation criteria, including the justification for the award"
+msgstr ""
+"Documentación de la evaluación de ofertas y la aplicación de los criterios "
+"de evaluación, incluyendo la justificación de la adjudicación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractGuarantees"
+msgstr "contractGuarantees"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Guarantees"
+msgstr "Garantías"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of guarantees relating to a contracting process or contract."
+msgstr ""
+"Documentación de los garantías relacionadas a un proceso de contratación o "
+"proyecto."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "defaultEvents"
+msgstr "defaultEvents"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Defaults"
+msgstr "Incumplimientos"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Information on events of default"
+msgstr "Información de eventos de incumplimiento"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "termination"
+msgstr "termination"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Termination"
+msgstr "Terminación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Information on contract termination"
+msgstr "Información de la terminación del proyecto"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "performanceReport"
+msgstr "performanceReport"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Performance report"
+msgstr "Reporte de desempeño"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Performance assessment reports"
+msgstr "Reportes de evaluación de desempeño"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "plannedProcurementNotice"
+msgstr "plannedProcurementNotice"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Notice of planned procurement"
+msgstr "Aviso de compra planeada"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A notice published by the procuring entity regarding their plans for future "
+"procurement, also known as a prior information notice. The procuring entity "
+"can use the notice of planned procurement as a tender notice."
+msgstr ""
+"Un aviso publicado por la entidad contratante acerca de sus planes para una "
+"futura compra, también conocida como aviso de información previa. La entidad"
+" contratante puede usar el aviso de compra planeada como un aviso de "
+"licitación."
+
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/documentType.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "OCDS"
+msgstr "OCDS"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "awardNotice"
+msgstr "awardNotice"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Award notice"
+msgstr "Aviso de adjudicación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"The formal notice that gives details of the contract award. This can be a "
+"link to a downloadable document, to a web page, or to an official gazette in"
+" which the notice is contained."
+msgstr ""
+"El aviso formal que da detalles de la adjudicación del contrato. Esto puede "
+"ser un enlace a un documento descargable, una página web, o a una gaceta "
+"oficial en la que el aviso está contenido."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractNotice"
+msgstr "contractNotice"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Contract notice"
+msgstr "Aviso de contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"The formal notice that gives details of a contract being signed and valid to"
+" start implementation. This can be a link to a downloadable document, to a "
+"web page, or to an official gazette in which the notice is contained."
+msgstr ""
+"El aviso formal que provee detalles de un contrato siendo firmado y válido "
+"para empezar la implementación. Este puede ser un enlace a un documento "
+"descargable, una página web o a una gaceta oficial en la que el aviso está "
+"contenido."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "completionCertificate"
+msgstr "completionCertificate"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Completion certificate"
+msgstr "Certificado de completitud"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A completion certificate issued by a relevant authority providing evidence "
+"that works were completed to a certain level of quality. Completion "
+"certificates might only be relevant for particular kinds of contracting "
+"processes."
+msgstr ""
+"Un certificado de finalización expedido por la autoridad relevante que "
+"provee evidencia de que las obras fueron finalizadas hasta un cierto nivel "
+"de calidad. Los certificados de finalización podrían ser relevantes sólo "
+"para tipos particulares de procesos de contratación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "procurementPlan"
+msgstr "procurementPlan"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Procurement plan"
+msgstr "Plan de adquisiciones"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation that sets out the basis for this particular contracting "
+"process."
+msgstr ""
+"Documentación que establece las bases para este proceso de contratación en "
+"particular."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "biddingDocuments"
+msgstr "biddingDocuments"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Bidding documents"
+msgstr "Documentos de oferta"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation for potential suppliers, describing the goals of the contract "
+"(e.g. goods and services to be procured), and the bidding process."
+msgstr ""
+"Documentación para potenciales proveedores que describe los objetivos del "
+"contrato (ej. bienes y servicios a ser adquiridos) y el proceso de "
+"licitación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractArrangements"
+msgstr "contractArrangements"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Arrangements for ending contract"
+msgstr "Arreglos para la finalización del contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Documentation of the arrangements for ending the contract(s)."
+msgstr "Documentación de los arreglos para finalizar el(los) contrato(s)."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractSchedule"
+msgstr "contractSchedule"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Contract schedules"
+msgstr "Apéndices del contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Any document which contains additional terms, obligations or information "
+"related to the contract, such as a schedule, appendix, annex, attachment or "
+"addendum."
+msgstr ""
+"Cualquier documento que contenga términos adicionales, obligaciones o "
+"información relacionada al contrado, tal como un programa, apéndice, anexo, "
+"adjunto o adenda."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "physicalProgressReport"
+msgstr "physicalProgressReport"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Physical progress reports"
+msgstr "Reporte de progreso físico"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation on the status of implementation, usually against key "
+"milestones."
+msgstr ""
+"Documentación del estado de la implementación, usualmente en comparación a "
+"hitos clave."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "financialProgressReport"
+msgstr "financialProgressReport"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Financial progress reports"
+msgstr "Reportes de progreso financiero"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation providing dates and amounts of stage payments made (against "
+"total amount) and the source of those payments, including cost overruns, if "
+"any. Structured versions of this information can be provided through "
+"contract implementation transactions."
+msgstr ""
+"Documentación que provee fechas y montos de los pagos realizados (a favor "
+"del monto total) y el origen de esos pagos, incluyendo sobrecostos si los "
+"hubiere. Versiones estructuradas de esta información pueden ser proveídas a "
+"través de transacciones en la implementación del contrato."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "hearingNotice"
+msgstr "hearingNotice"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Public hearing notice"
+msgstr "Aviso de audiencia pública"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of any public hearings that took place as part of the planning"
+" for this contracting process."
+msgstr ""
+"Documentación de cualquier audencia pública que haya tomado lugar como parte"
+" de la planificación de este proceso de contratación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "marketStudies"
+msgstr "marketStudies"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Market studies"
+msgstr "Estudios de mercado"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of any market studies that took place as part of the planning "
+"for this contracting process."
+msgstr ""
+"Documentación de cualquier estudio de mercado que haya tomado lugar como "
+"parte de la planificación de este proceso de contratación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "eligibilityCriteria"
+msgstr "eligibilityCriteria"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Eligibility criteria"
+msgstr "Criterios de elegibilidad"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Detailed documents about the eligibility of bidders."
+msgstr "Documentos detallados sobre la elegibilidad de los licitantes."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "clarifications"
+msgstr "aclaraciones"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Clarifications to bidders questions"
+msgstr "Aclaraciones a las preguntas de los licitantes."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation that provides replies to issues raised in pre-bid conferences "
+"or an enquiry processes."
+msgstr ""
+"Documentación que provee respuestas a las cuestiones tratadas en audiencias "
+"pre-licitación o en un proceso de consultas."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "assetAndLiabilityAssessment"
+msgstr "assetAndLiabilityAssessment"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Assessment of government's assets and liabilities"
+msgstr "Evaluación de los activos y pasivos del gobierno"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation covering assessments of the government's assets and "
+"liabilities related to this contracting process."
+msgstr ""
+"Documentación que cubre evaluaciones de los activos y pasivos del gobierno "
+"relacionados a este proceso de contratación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "riskProvisions"
+msgstr "riskProvisions"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Provisions for management of risks and liabilities"
+msgstr "Provisiones para el manejo de riesgos y responsabilidades"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation covering how risks will be managed as part of this contracting"
+" process."
+msgstr ""
+"Documentación que cubre cómo los riesgos serán manejados como parte de este "
+"proceso de contratación."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "winningBid"
+msgstr "winningBid"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Winning bid"
+msgstr "Oferta ganadora"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of the winning bid, including, wherever applicable, a full "
+"copy of the proposal received."
+msgstr ""
+"Documentación de la oferta ganadora incluyendo, cuando sea aplicable, una "
+"copia completa de la propuesta recibida."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "complaints"
+msgstr "quejas"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Complaints and decisions"
+msgstr "Quejas y decisiones"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of any complaints received, or decisions in response to "
+"complaints."
+msgstr ""
+"Documentación de cualquier queja recibida, o decisiones en respuesta a "
+"quejas."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractAnnexe"
+msgstr "contractAnnexe"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Annexes to the contract"
+msgstr "Anexos al contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Copies of annexes and other supporting documentation related to the "
+"contract."
+msgstr ""
+"Copias de anexos y otra documentación de apoyo relacionada a este contrato."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "subContract"
+msgstr "subContract"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Subcontracts"
+msgstr "Subcontratos"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation detailing subcontracts and/or providing a copy of subcontracts"
+" themselves. Where OCDS data on the subcontracts exists, this can be "
+"declared using the relatedProcess block."
+msgstr ""
+"Documentación que detalla subcontratos y/o provee una copia de subcontratos "
+"mismos. Cuando existen datos OCDS sobre subcontratos, esto puede ser "
+"declarado usando el bloque relatedProcess."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "needsAssessment"
+msgstr "needsAssessment"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Needs assessment"
+msgstr "Evaluación de necesidades"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of the needs assessments carried out for this contracting "
+"process or project addressing demand for the project or investment from the "
+"affected communities or users."
+msgstr ""
+"Documentación de las evaluaciones de necesidades (requerimientos) llevadas a"
+" cabo para este proyecto, que abordan las motivaciones del proyecto o "
+"inversión por parte de las comunidades o usuarios afectados."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "projectPlan"
+msgstr "projectPlan"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Project plan"
+msgstr "Plan de proyecto"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of project planning for this contracting process, and, where "
+"applicable, a copy of the project plan document."
+msgstr ""
+"Documentación de la planificación del proyecto para este proceso de "
+"contratación y, cuando sea aplicable, una copia del documento del plan de "
+"proyecto."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "billOfQuantity"
+msgstr "billOfQuantity"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Bill of quantity"
+msgstr "Estimación cuantitativa"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation that provides itemized information on materials, parts and "
+"labour, and the terms and conditions for their provision, providing "
+"information that would enable bidders to price work effectively. Structured "
+"versions of item and quantity information at each of tender, award and "
+"contract stage can be provided using units within the items building block."
+msgstr ""
+"Documentación que provee información desglosada de materiales, partes y mano"
+" de obra, y los términos y condiciones para su provisión, brindando "
+"información que permitiría a los licitantes establecer efectivamente los "
+"precios. Versiones estructuradas de información de artículos y cantidades "
+"durante las fases de licitación, adjudicación y contrato pueden ser "
+"proveídas usando unidades dentro del bloque de artículos. "
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "bidders"
+msgstr "bidders"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Information on bidders"
+msgstr "Información de licitantes"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation on bidders or participants, their validation documents and any"
+" procedural exemptions for which they qualify."
+msgstr ""
+"Documentación sobre los oferentes o participantes, sus documentos de "
+"validación y cualquier excepción de procedimientos para el cual califiquen."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "conflictOfInterest"
+msgstr "conflictOfInterest"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Conflict of interest"
+msgstr "Conflicto de interés"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Documentation of conflicts of interest declared or uncovered."
+msgstr "Documentación de conflictos de interés declarados o descubiertos."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "debarments"
+msgstr "debarments"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Debarments"
+msgstr "Inhabilitaciones"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Documentation of any debarments issued."
+msgstr "Documentación de cualquier inhabilitación emitida."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "illustration"
+msgstr "illustration"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Illustrations"
+msgstr "Ilustraciones"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Images intended to provide supporting information. The URL for images should"
+" be directly to an image file that applications can display as part of a "
+"gallery of images. At the tender stage, images can be illustrations of "
+"goods, works or services needed or for sale. At the implementation stage, "
+"images can be illustrations or visual evidence of physical progress."
+msgstr ""
+"Imágenes destinadas a proveer información de soporte. La URL para imágenes "
+"debería estar dirigida directamente a un archivo de imagen que las "
+"aplicaciones puedan desplegar como parte de una galería de imágenes. En la "
+"fase de licitación, las imágenes pueden ser ilustraciones de bienes, "
+"trabajos o servicios requeridos o a la venta. En la fase de implementación, "
+"las imágenes pueden ser ilustraciones o evidencia visual de progreso físico."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "submissionDocuments"
+msgstr "submissionDocuments"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Bid submission documents"
+msgstr "Documentos de presentación de oferta"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Documentation submitted by a bidder as part of their proposal."
+msgstr "Documentación presentada por un licitante como parte de su propuesta."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "contractSummary"
+msgstr "contractSummary"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Contract summary"
+msgstr "Resumen del contrato"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation providing an overview of the key terms and sections of the "
+"contract. Commonly used for large and complex contracts."
+msgstr ""
+"Documentación que provee una vista general de los términos y secciones clave"
+" del contrato. Usado comúnmente para contratos largos y complejos."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "cancellationDetails"
+msgstr "cancellationDetails"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Cancellation details"
+msgstr "Detalles de cancelación"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Documentation of the arrangements, or reasons, for cancellation of a "
+"contracting process, award or specific contract."
+msgstr ""
+"Documentación de los acuerdos, o razones, para la cancelación de un proceso "
+"de contratación, adjudicación o contrato específico."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "projectScope"
+msgstr "projectScope"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Project scope"
+msgstr "Alcance del proyecto"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"A description of the main outputs from the project that are being taken "
+"forward into construction (including type, quantity and units)"
+msgstr ""
+"Una descripción de los principales objetos del proyecto que serán llevados a"
+" construcción (incluyendo tipo, cantidad y unidades)."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "landAndSettlementImpact"
+msgstr "landAndSettlementImpact"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Land and Settlement Impact"
+msgstr "Impacto en tierras y (re) asentamiento"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"State the amount of land and property that was acquired for the project "
+"(e.g. 25sq km land), and outline related impacts (e.g. archaeological issues"
+" (moved Saxon burial site), local/indigenous settlements (relocated 5 "
+"indigenous villages of 500 villagers each), impacts on local businesses e.g."
+" (30 business properties purchased))."
+msgstr ""
+"Indica la cantidad de tierras y propiedades que fueron adquiridas para el "
+"proyecto (ej. 25km² de tierras), y resume los impactos relacionados (ej. "
+"problemas arqueológicos (se relocalizó un cementerio sajón), asentamientos "
+"locales/indígenas (se relocalizaron 5 aldeas indígenas de 500 habitantes "
+"cada una), impactos en negocios locales (ej. se compraron 30 propiedades "
+"comerciales))."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "projectEvaluation"
+msgstr "projectEvaluation"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Project evaluation"
+msgstr "Evaluación del proyecto"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid ""
+"Generally published at the conclusion of a project, providing a technical "
+"and financial summary of delivery."
+msgstr ""
+"Generalmente publicado al término de un proyecto, provee un resumen técnico "
+"y financiero de la entrega."
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "budgetApproval"
+msgstr "budgetApproval"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Budget approval"
+msgstr "Aprobación del presupuesto"
+
+#: ../current_lang/codelists/documentType.csv:1
+msgid "Additional details about the approval of the budget."
+msgstr "Detalles adicionales sobre la aprobación del presupuesto."
+
+#: ../../docs/reference/codelists.md:93
+msgid "ModificationType"
+msgstr "ModificationType"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "duration"
+msgstr "duration"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "Duration"
+msgstr "Duración"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid ""
+"This modification describes a change to the contract duration. This may be "
+"identified based on changes in `award.contractPeriod` or `contract.period`, "
+"or updates to milestones and payments that appear to exceed the anticipated "
+"`contract.period`."
+msgstr ""
+"Esta modificación describe un cambio a la duración del contrato. Este puede "
+"ser identificado en base a los cambios en `award.contractPeriod` o "
+"`contract.period`, o actualizaciones a hitos y pagos que parezcan exceder el"
+" `contract.period` anticipado."
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "value"
+msgstr "value"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "Value"
+msgstr "Valor"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid ""
+"This modification describes a change to the contract value. This may be "
+"identified based on changes to the sum of `contract.value` (watching for "
+"cases where a contract value is varied, or an additional extension contract "
+"is signed as part of this process), or by monitoring "
+"`contracts.implementation.transactions`."
+msgstr ""
+"Esta modificación describe un cambio en el valor del contrato. Esto puede "
+"ser identificado basándose en cambios en la suma de `contract.value` "
+"(buscando casos en los que el valor de un contrato es cambiado, o un "
+"contrato adicional de extensión es firmado como parte de este proceso), o "
+"monitoreando `contracts.implementation.transactions`."
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "scope"
+msgstr "scope"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid "Scope"
+msgstr "Alcance"
+
+#: ../current_lang/codelists/modificationType.csv:1
+msgid ""
+"This modification describes a change to the contract scope. This may be "
+"identified by comparing key details from `tender`, `awards` and `contracts`,"
+" or by monitoring relevant documents."
+msgstr ""
+"Esta modificación describe un cambio al alcance del contrato. Esto puede ser"
+" identificado comparando detalles clave de `tender`, `awards`, y "
+"`contracts`, o monitoreando documentos relevantes."
+
+#: ../../docs/reference/codelists.md:104
+msgid "PartyRole"
+msgstr "PartyRole"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "buyer"
+msgstr "buyer"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Buyer"
+msgstr "Comprador"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"A buyer is an entity whose budget will be used to pay for goods, works or "
+"services related to a contract."
+msgstr ""
+"Un comprador es una entidad cuyo presupuesto será usado para pagar por "
+"bienes, obras o servicios relacionados a un contrato."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "procuringEntity"
+msgstr "procuringEntity"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Procuring entity"
+msgstr "Entidad contratante"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"The entity managing the procurement. This can be different from the buyer "
+"who pays for, or uses, the items being procured."
+msgstr ""
+"La entidad que está administrando la adquisición. Esta puede ser diferente "
+"del comprador que paga, o usa, los artículos que están siendo adquiridos."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "supplier"
+msgstr "supplier"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Supplier"
+msgstr "Proveedor"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "An entity awarded or contracted to provide goods, works or services."
+msgstr ""
+"Una entidad adjudicada o contratada para proveer bienes, obras o servicios."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "tenderer"
+msgstr "tenderer"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Tenderer"
+msgstr "Licitante"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "All entities who submit a tender."
+msgstr "Todas las entidades que presentan una oferta."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "funder"
+msgstr "funder"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Funder"
+msgstr "Financiador"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"The funder is an entity providing money or finance for this contracting "
+"process or project."
+msgstr ""
+"El financiador es una entidad que provee dinero o financiación para este "
+"proceso de contratación o proyecto."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "enquirer"
+msgstr "enquirer"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Enquirer"
+msgstr "Persona que solicita información"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"A party who has made an enquiry during the enquiry phase of a contracting "
+"process."
+msgstr ""
+"Una parte que ha realizado un pedido de información durante la fase de "
+"solicitudes de información de un proceso de contratación."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "payer"
+msgstr "payer"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Payer"
+msgstr "Pagador"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "A party making a payment from a transaction."
+msgstr "Una parte que hace un pago en una transacción."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "payee"
+msgstr "payee"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Payee"
+msgstr "Beneficiario"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "A party in receipt of a payment from a transaction."
+msgstr "Una parte que recibe un pago en una transacción."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "reviewBody"
+msgstr "reviewBody"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Review body"
+msgstr "Órgano de revisión"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"A party responsible for the review of this procurement process. This party "
+"often has a role in any challenges made to the contract award."
+msgstr ""
+"Una parte responsable de la revisión de este proceso de adquisición. Esta "
+"parte tiene a menudo un papel en cualquier cuestionamiento hecho a la "
+"adjudicación del contrato."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "interestedParty"
+msgstr "interestedParty"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Interested party"
+msgstr "Parte interesada"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"A party that has expressed an interest in the contracting process: for "
+"example, by purchasing tender documents or submitting clarification "
+"questions."
+msgstr ""
+"Una parte que ha expresado interés en el proceso de contratación: por "
+"ejemplo, comprando documentación del concurso o presentando preguntas "
+"aclaratorias."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "publicAuthority"
+msgstr "publicAuthority"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Public Authority"
+msgstr "Autoridad Pública"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid ""
+"The entity responsible for developing the infrastructure assets and/or "
+"delivering the public services in this project."
+msgstr ""
+"La entidad responsable de desarrollar los activos de infraestructura y/o de "
+"entregar los servicios públicos en este proyecto."
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "administrativeEntity"
+msgstr "administrativeEntity"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "Administrative Entity"
+msgstr "Entidad Administrativa"
+
+#: ../current_lang/codelists/partyRole.csv:1
+msgid "The entity responsible for contract administration."
+msgstr "La entidad responsable de la administración de contratos."
+
+#: ../../docs/reference/codelists.md:115
+msgid "ProjectSector"
+msgstr "ProjectSector"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "education"
+msgstr "education"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Education"
+msgstr "Educación"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Education, including schools, universities and other learning and training "
+"facilities"
+msgstr ""
+"Educación, incluyendo escuelas, universidades y otras instalaciones de "
+"aprendizaje y entrenamiento."
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "health"
+msgstr "health"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Health"
+msgstr "Salud"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Health, including hospitals, healthcare and human services"
+msgstr "Salud, incluyendo hospitales, servicios humanos y cuidado de la salud"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "energy"
+msgstr "energy"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Energy"
+msgstr "Energía"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Energy, including electric power generation, and the transmission and "
+"distribution of electricity, oil and gas, for example: power plants, power "
+"lines, gas pipelines"
+msgstr ""
+"Energía, incluyendo generación de energía eléctrica y la transmisión y "
+"distribución de electricidad, petróleo y gas, por ejemplo: plantas de "
+"energía, líneas eléctricas, gasoductos"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "communications"
+msgstr "communications"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Communications"
+msgstr "Comunicaciones"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Communications, including ICT, IT, telecommunications, postal facilities, "
+"high-speed internet, broadband"
+msgstr ""
+"Comunicaciones, incluyendo TIC, TI, telecomunicaciones, instalaciones "
+"postales, internet de alta velocidad, banda ancha"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "waterAndWaste"
+msgstr "waterAndWaste"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Water and waste"
+msgstr "Agua y residuos"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Water and waste, including sanitation and wastewater"
+msgstr "Agua y residuos, incluyendo saneamiento y aguas residuales"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "governance"
+msgstr "governance"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Governance"
+msgstr "Gobernanza"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Governance, including government accommodations, public buildings, "
+"government offices; justice, courts; emergency services / response, local "
+"security; security, prisons, corrections; defence, military"
+msgstr ""
+"Gobernanza, incluyendo instalaciones del gobierno, edificios públicos, "
+"oficinas gubernamentales; justicia, cortes; servicios de emergencia y "
+"respuesta a emergencias, seguridad local; seguridad, prisiones, "
+"correccionales; defensa, fuerzas armadas"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "economy"
+msgstr "economy"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Economy"
+msgstr "Economía"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Economy, including agribusiness, agriculture, science and environment"
+msgstr "Economía, incluyendo agronegocios, agricultura, ciencia y ambiente"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "cultureSportsAndRecreation"
+msgstr "cultureSportsAndRecreation"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Culture, sports and recreation"
+msgstr "Cultura, deportes y recreación"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Culture, sports and recreation, including tourism, parks and green areas"
+msgstr ""
+"Cultura, deportes y recreación, incluyendo turismo, parques y áreas verdes"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport"
+msgstr "transport"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Transport"
+msgstr "Transporte"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Transport. A more detailed breakdown may be provided using the "
+"transport.[mode] codes"
+msgstr ""
+"Transporte. Se puede proveer un desglose detallado usando los códigos "
+"transport.[mode]"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport.air"
+msgstr "transport.air"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Air transport"
+msgstr "Transporte aéreo"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Air transport, including airports, airways and aviation"
+msgstr "Transporte aéreo, incluyendo aeropuertos, vías aéreas y aviación"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport.water"
+msgstr "transport.water"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Water transport"
+msgstr "Transporte fluvial"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Water transport, including ports and inland waterways"
+msgstr ""
+"Transporte fluvial, incluyendo puertos y navegación en aguas interiores "
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport.rail"
+msgstr "transport.rail"
+
+#: ../current_lang/codelists/projectSector.csv:1
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Rail transport"
+msgstr "Transporte ferroviario"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport.road"
+msgstr "transport.road"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Road transport"
+msgstr "Transporte vial"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Road transport, including roads, highways, streets, tunnels and bridges"
+msgstr ""
+"Transporte vial, incluyendo carreteras, autopistas, calles, túneles y "
+"puentes"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "transport.urban"
+msgstr "transport.urban"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Urban transport"
+msgstr "Transporte urbano"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid ""
+"Urban transport, including mass transit, urban mobility, buses, cycling, "
+"walking and taxi"
+msgstr ""
+"Transporte urbano, incluyendo tránsito masivo, movilidad urbana, buses, "
+"ciclismo, vías peatonales y taxi"
+
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "socialHousing"
+msgstr "socialHousing"
+
+#: ../current_lang/codelists/projectSector.csv:1
+#: ../current_lang/codelists/projectSector.csv:1
+msgid "Social housing"
+msgstr "Vivienda social"
+
+#: ../../docs/reference/codelists.md:126
+msgid "RelatedProject"
+msgstr "RelatedProject"
+
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid ""
+"The related project is the initial construction of the set of infrastructure"
+" assets."
+msgstr ""
+"El proyecto relacionado es la construcción inicial del conjunto de activos "
+"de infraestructura."
+
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid ""
+"The related project might result in the rehabilitation of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en la rehabilitación del mismo "
+"conjunto de activos de infraestructura."
+
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid ""
+"The related project might result in the replacement of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en el reemplazo del mismo conjunto de"
+" activos de infraestructura."
+
+#: ../current_lang/codelists/relatedProject.csv:1
+msgid ""
+"The related project might result in the expansion of the same set of "
+"infrastructure assets."
+msgstr ""
+"El proyecto relacionado puede resultar en la expansión del mismo conjunto de"
+" activos de infraestructura."
+
+#: ../../docs/reference/codelists.md:137
+msgid "RelatedProjectScheme"
+msgstr "RelatedProjectScheme"
+
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid "oc4ids"
+msgstr "oc4ids"
+
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid "OC4IDS project id"
+msgstr "ID de proyecto OC4IDS"
+
+#: ../current_lang/codelists/relatedProjectScheme.csv:1
+msgid ""
+"An Open Contracting for Infrastructure Data Standards project identifier"
+msgstr ""
+"Un identificador de proyecto de los Estándares de Datos de Contrataciones "
+"Abiertas para Infraestructura"

--- a/locale/es/LC_MESSAGES/reference/index.po
+++ b/locale/es/LC_MESSAGES/reference/index.po
@@ -1,0 +1,128 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/index.md:1
+msgid "Schema reference"
+msgstr "Referencia del Esquema"
+
+#: ../../docs/reference/index.md:3
+msgid ""
+"The Open Contracting for Infrastructure Data Standard (OC4IDS) provides a "
+"common approach for the disclosure of structured data on infrastructure "
+"projects and their related contracting processes."
+msgstr ""
+"Las Contrataciones Abiertas para el Estándar de Datos sobre Infraestructura "
+"(OC4IDS, por sus siglas en inglés) provee un esquema común para la "
+"divulgación de datos estructurados sobre proyectos de infraestructura y sus "
+"procesos de contratación relacionados."
+
+#: ../../docs/reference/index.md:5
+msgid ""
+"OC4IDS is comprised of a schema file and codelist files, and reference "
+"documentation is available for the [schema](schema) and "
+"[codelists](codelists)."
+msgstr ""
+"OC4IDS está compuesto de un archivo de esquema y archivos de listas de "
+"código, y la documentación de referencia está disponible para el "
+"[esquema](schema) y las [listas de código](codelists)."
+
+#: ../../docs/reference/index.md:7
+msgid ""
+"The schema can be explored using the [schema browser](browser) and can be "
+"[downloaded here](../project-schema.json). The schema is expressed using "
+"[JSON Schema, draft 4](https://tools.ietf.org/html/draft-zyp-json-"
+"schema-04)."
+msgstr ""
+"El esquema puede ser explorado usando el [navegador del esquema](browser) y "
+"puede ser [descargado aquí](../project-schema.json). El esquema está escrito"
+" usando [JSON Schema, borrador 4](https://tools.ietf.org/html/draft-zyp-"
+"json-schema-04)."
+
+#: ../../docs/reference/index.md:9
+msgid ""
+"OC4IDS data must be published as part of a [project package](package), which"
+" serves as a container for data on multiple projects and adds important "
+"metadata about the data publication."
+msgstr ""
+"Los datos OC4IDS deben ser publicados como parte de un [paquete de "
+"proyectos](package), que sirve como un contenedor para datos de múltiples "
+"proyectos y añade metadatos importantes sobre la publicación de los datos."
+
+#: ../../docs/reference/index.md:11
+msgid ""
+"The OC4IDS schema reuses many of the building blocks from the Open "
+"Contracting Data Standard; these are introduced in the [Getting Started "
+"section of the OCDS documentation](https://standard.open-"
+"contracting.org/1.1/en/getting_started/)."
+msgstr ""
+"El esquema OC4IDS reutiliza mucho de los bloques del Estándar de Datos de "
+"Contrataciones Abiertas; estos son presentados en la [sección de 'Para "
+"empezar' de la documentación de OCDS](https://standard.open-"
+"contracting.org/1.1/es/getting_started/)."
+
+#: ../../docs/reference/index.md:26
+msgid "Data validation"
+msgstr "Validación de los Datos"
+
+#: ../../docs/reference/index.md:28
+msgid ""
+"OC4IDS uses a permissive schema. It does not enforce strong technical "
+"validation requirements on data, other than some structural rules and data "
+"type rules (dates, numbers and strings)."
+msgstr ""
+"OC4IDS utiliza un esquema permisivo. No se fuerzan requisitos de validación "
+"técnica estrictos en los datos, aparte de algunas reglas estructurales y "
+"reglas de tipos de datos (fechas, números y cadenas de texto)."
+
+#: ../../docs/reference/index.md:30
+msgid ""
+"The fact that data validates against the schema cannot be used to make any "
+"judgment about the quality of that data."
+msgstr ""
+"El hecho de que los datos se validen contra el esquema no puede ser usado "
+"para emitir juicio acerca de la calidad de los datos."
+
+#: ../../docs/reference/index.md:32
+msgid "Extending the schema"
+msgstr "Extendiendo el esquema"
+
+#: ../../docs/reference/index.md:34
+msgid ""
+"The schema does not restrict the use of additional objects or fields. As a "
+"result, publishers of data are free to add extra details to their data."
+msgstr ""
+"El esquema no restringe el uso de objetos o campos adicionales. Por lo "
+"tanto, los publicadores de datos son libres de añadir detalles extra a sus "
+"datos."
+
+#: ../../docs/reference/index.md:36
+msgid ""
+"No formal extensions mechanism currently exists for OC4IDS. However, the "
+"extensions mechanism from the Open Contracting Data Standard should be used "
+"as a reference model if such a mechanism is required in future."
+msgstr ""
+"Actualmente no existe un mecanismo formal de extensiones para OC4IDS. Sin "
+"embargo, el mecanismo de extensiones del Estándar de Datos de Contrataciones"
+" Abiertas debería ser usado como un modelo de referencia si se requiere de "
+"un mecanismo en el futuro."

--- a/locale/es/LC_MESSAGES/reference/package.po
+++ b/locale/es/LC_MESSAGES/reference/package.po
@@ -1,0 +1,56 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/package.md:1
+msgid "Packaging data"
+msgstr "Datos del Paquete"
+
+#: ../../docs/reference/package.md:3
+msgid ""
+"OC4IDS data must be published as part of project package, which acts as a "
+"container for data on multiple projects and adds important metadata about "
+"the publication. The project package schema describes this container."
+msgstr ""
+"Los datos OC4IDS deben ser publicados como parte de un paquete de proyecto, "
+"que funciona como un contenedor de datos de múltiples proyectos y agrega "
+"metadatos importantes sobre la publicación. El esquema de paquete de "
+"proyecto describe este contenedor."
+
+#: ../../docs/reference/package.md:5
+msgid ""
+"You can view an interactive version of the project package schema below "
+"(requires JavaScript) or [download it here](../../project-package-"
+"schema.json)."
+msgstr ""
+"Puede ver una versión interactiva del esquema de paquete de proyectos más "
+"abajo (requiere JavaScript) o [descárguelo aquí](../../project-package-"
+"schema.json)."
+
+#: ../../docs/reference/package.md:7
+msgid ""
+"Click on schema elements to expand the tree, or use the '+' icon to expand "
+"all elements. Use { } to view the underlying schema for any section."
+msgstr ""
+"Haga clic en los elementos del esquema para expandir el árbol, o use el "
+"ícono '+' para expandir todos los elementos. Use {} para ver el esquema "
+"subyacente para cada sección."

--- a/locale/es/LC_MESSAGES/reference/schema.po
+++ b/locale/es/LC_MESSAGES/reference/schema.po
@@ -1,0 +1,341 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Maria Esther Cervantes <mariaesther@idatosabiertos.org>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:13+0000\n"
+"Last-Translator: Evelyn Dinora Hernandez Martinez <e.hernandez@infrastructuretransparency.org>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/reference/schema.md:7
+msgid "Schema reference"
+msgstr "Referencia del Esquema"
+
+#: ../../docs/reference/schema.md:9
+msgid ""
+"The tables below describe each of the fields and objects in OC4IDS. To see "
+"how they fit together, consult the [schema browser](browser)."
+msgstr ""
+"Las tablas de abajo describen cada uno de los campos y objetos en OC4IDS. "
+"Para ver cómo estos encajan juntos, consulte el [navegador del "
+"esquema](browser)."
+
+#: ../../docs/reference/schema.md:11
+msgid "Project"
+msgstr "Proyecto (Project)"
+
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1
+msgid "Title"
+msgstr "Título"
+
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1
+msgid "Description"
+msgstr "Descripción"
+
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1
+msgid "Type"
+msgstr "Tipo"
+
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1
+msgid "Format"
+msgstr "Formato"
+
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1 ../../sphinxcontrib-jsonschema:1
+#: ../../sphinxcontrib-jsonschema:1
+msgid "Required"
+msgstr "Requerido"
+
+#: ../../docs/reference/schema.md:20
+msgid "ContractingProcess"
+msgstr "Proceso de Contratación (ContractingProcess)"
+
+#: ../../docs/reference/schema.md:32
+msgid "ContractingProcessSummary"
+msgstr "Resumen de Proceso de Contratación (ContractingProcessSummary)"
+
+#: ../../docs/reference/schema.md:44
+msgid "LinkedRelease"
+msgstr "Entrega Enlazada (LinkedRelease)"
+
+#: ../../docs/reference/schema.md:55
+msgid "Components"
+msgstr "Componentes"
+
+#: ../../docs/reference/schema.md:57
+msgid "Address"
+msgstr "Dirección (Address)"
+
+#: ../../docs/reference/schema.md:59
+msgid ""
+"We use properties from schema.org and vCard for address components. In the "
+"event source data cannot be broken down into these parts, data SHOULD "
+"contain at least a streetAddress value and postal code."
+msgstr ""
+"Usamos propiedades de schema.org y vCard para componentes de dirección. En "
+"el evento en que los datos fuente no puedan ser desglosados en estas partes,"
+" los datos DEBERÍAN contener al menos una calle (streetAddress) y código "
+"postal."
+
+#: ../../docs/reference/schema.md:61
+msgid ""
+"When working with data, users should be aware that addresses may not always "
+"be broken down using all the properties the specification provides."
+msgstr ""
+"Cuando se trabaja con los datos, los usuarios deben tener en cuenta que las "
+"direcciones no siempre están separadas en todas las propiedades que provee "
+"la especificación."
+
+#: ../../docs/reference/schema.md:72
+msgid "BudgetBreakdown"
+msgstr "Desglose del Presupuesto (BudgetBreakdown)"
+
+#: ../../docs/reference/schema.md:74
+msgid ""
+"A budget breakdown is provided through an array of `BudgetBreakdown` "
+"objects, each of which represents budget for a particular period, from a "
+"particular source, or a combination of the two."
+msgstr ""
+"Un desglose del presupuesto se provee por medio de una lista de objetos "
+"`BudgetBreakdown`, cada una de las cuales representa un presupuesto para un "
+"período particular, de una fuente particular, o una combinación de ambos."
+
+#: ../../docs/reference/schema.md:76
+msgid ""
+"See the [documentation of the OCDS Budget Breakdown "
+"extension](https://github.com/open-contracting-"
+"extensions/ocds_budget_breakdown_extension) for more details of this data "
+"model. BudgetBreakdown can also be extended further to include budget "
+"classifications data following the pattern described in the [OCDS Budgets "
+"and Spend extension](https://github.com/open-contracting-"
+"extensions/ocds_budget_and_spend_extension)."
+msgstr ""
+"Vea la [documentación de la extensión de OCDS 'Desglose del "
+"Presupuesto'](https://github.com/open-contracting-"
+"extensions/ocds_budget_breakdown_extension) para más detalles sobre este "
+"modelo de datos. Este modelo puede ser extendido de nuevo para agregar datos"
+" de clasificaciones del presupuesto de acuerdo al patrón descrito en la "
+"[extensión OCDS  'Presupuestos y Gasto'](https://github.com/open-"
+"contracting-extensions/ocds_budget_and_spend_extension)."
+
+#: ../../docs/reference/schema.md:87
+msgid "Classification"
+msgstr "Clasificación (Classification)"
+
+#: ../../docs/reference/schema.md:89
+msgid ""
+"A classification consists of an identifier for the codelist (the `scheme`) "
+"and a code from that codelist (the `id`), and then a human-readable label "
+"for the classification (the `description`)."
+msgstr ""
+"Una clasificación consiste en un identificador para la lista de códigos (el "
+"esquema -`scheme`- ) y un código de esa lista (el `id`), y una etiqueta de "
+"la clasificación legible por humanos (la descripción -`description`-)."
+
+#: ../../docs/reference/schema.md:100
+msgid "For example:"
+msgstr "Por ejemplo:"
+
+#: ../../docs/reference/schema.md:110
+msgid "ContactPoint"
+msgstr "Punto de Contacto (ContactPoint)"
+
+#: ../../docs/reference/schema.md:121
+msgid "Document"
+msgstr "Documento (Document)"
+
+#: ../../docs/reference/schema.md:123
+msgid ""
+"For each document the following structured information may be provided."
+msgstr ""
+"Se puede proveer la siguiente información estructurada por cada documento."
+
+#: ../../docs/reference/schema.md:134
+msgid "Identifier"
+msgstr "Identificador (Identifier)"
+
+#: ../../docs/reference/schema.md:136
+msgid ""
+"Use of stable official organization identifiers can help join up data "
+"between systems."
+msgstr ""
+"El uso de identificadores oficiales estables de la organización puede ayudar"
+" a unir los datos de diferentes sistemas."
+
+#: ../../docs/reference/schema.md:138
+msgid ""
+"Organization identifiers should be constructed by collecting an official "
+"company (or government body) registration number for the organization, and "
+"then finding the [org-id.guide list code](http://www.org-id.guide) for the "
+"list this identifier is taken from to use in the `scheme` field."
+msgstr ""
+"Los identificadores de la organización deberían ser construidos recogiendo "
+"el número de registro oficial de la compañía (o del ente gubernamental), y "
+"luego buscando el [código de lista de org-id.guide](http://www.org-id.guide)"
+" para la lista de la cual este identificador es tomado para utilizarlo en el"
+" campo `scheme`."
+
+#: ../../docs/reference/schema.md:140
+msgid ""
+"For example, if identifying a company in Colombia, look up its identifier in"
+" the [Unified Commercial and Social Registry](http://org-id.guide/list/CO-"
+"RUE) and use the list code `CO-RUE`."
+msgstr ""
+"Por ejemplo, si se quiere identificar una empresa en Colombia, busque su "
+"identificador en el [Registro Único Empresarial y Social](http://org-"
+"id.guide/list/CO-RUE) y use el código de lista `CO-RUE`."
+
+#: ../../docs/reference/schema.md:151
+msgid "Location"
+msgstr "Ubicación (Location)"
+
+#: ../../docs/reference/schema.md:153
+msgid ""
+"A project may have one or more locations. Locations may be expressed in a "
+"number of different ways, using one or more of:"
+msgstr ""
+"Un proyecto puede tener una o más ubicaciones. Las ubicaciones pueden "
+"expresarse de diferentes maneras, usando uno o más de los siguientes:"
+
+#: ../../docs/reference/schema.md:155
+msgid ""
+"A point location or geometry (e.g. trace of a road, or polygon giving the "
+"boundary of a site);"
+msgstr ""
+"Un punto de ubicación o una forma geométrica (ej. el trazo de una ruta, o un"
+" polígono que delimita un sitio);"
+
+#: ../../docs/reference/schema.md:156
+msgid "A gazetteer entry (e.g. town name);"
+msgstr "Una entrada en un diccionario geográfico (ej. nombre de un pueblo);"
+
+#: ../../docs/reference/schema.md:157
+msgid "An address."
+msgstr "Una dirección."
+
+#: ../../docs/reference/schema.md:168
+msgid "Modification"
+msgstr "Modificación (Modification)"
+
+#: ../../docs/reference/schema.md:170
+msgid ""
+"For each modification, the following structured information may be provided."
+msgstr ""
+"Se puede proveer la siguiente información estructurada por cada "
+"modificación."
+
+#: ../../docs/reference/schema.md:181
+msgid "Organization"
+msgstr "Organización (Organization)"
+
+#: ../../docs/reference/schema.md:183
+msgid "For each organization, provide as much structured data as you can."
+msgstr "Para cada organización, provea tantos datos estructurados como pueda."
+
+#: ../../docs/reference/schema.md:193
+msgid "OrganizationReference"
+msgstr "Referencia a Organización (OrganizationReference)"
+
+#: ../../docs/reference/schema.md:204
+msgid "Period"
+msgstr "Periodo (Period)"
+
+#: ../../docs/reference/schema.md:206
+msgid ""
+"Dates MUST be expressed using a full ISO 8601 date-time including a "
+"timezone. E.g.:"
+msgstr ""
+"Fechas DEBEN ser expresadas usando el formato ISO 8601 de fecha y hora "
+"completos incluyendo una zona horaria. Ejemplo:"
+
+#: ../../docs/reference/schema.md:208
+msgid "2018-09-18T11:26:04+01:00"
+msgstr "2018-09-18T11:26:04+01:00"
+
+#: ../../docs/reference/schema.md:210
+msgid ""
+"Where the source system does not contain time information, a judgment should"
+" be made as to the relevant time to attach (e.g. start of the day; end of "
+"the working day etc.)."
+msgstr ""
+"Cuando el sistema fuente no contenga información de hora, se debe decidir la"
+" hora pertinente a añadir (ej. inicio del día, final de la jornada laboral, "
+"etc.)."
+
+#: ../../docs/reference/schema.md:221
+msgid "RelatedProject"
+msgstr "Proyecto Relacionado (RelatedProject)"
+
+#: ../../docs/reference/schema.md:223
+msgid ""
+"A reference to a project related to the same set of infrastructure assets as"
+" the current project."
+msgstr ""
+"Una referencia a un proyecto relacionado al mismo conjunto de activos de "
+"infraestructura del proyecto actual."
+
+#: ../../docs/reference/schema.md:234
+msgid "Value"
+msgstr "Valor (Value)"
+
+#: ../../docs/reference/schema.md:236
+msgid ""
+"All values should be published along with their currency using the following"
+" structure."
+msgstr ""
+"Todos los valores deberían ser publicados junto con su moneda usando la "
+"estructura que sigue."

--- a/locale/es/LC_MESSAGES/sphinx.po
+++ b/locale/es/LC_MESSAGES/sphinx.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2020-05-13 23:47+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/_templates/layout.html:15
+msgid "Data Review Tool"
+msgstr "Herramienta de Revisión de Datos"

--- a/locale/es/LC_MESSAGES/support.po
+++ b/locale/es/LC_MESSAGES/support.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) Open Contracting Partnership
+# This file is distributed under the same license as the Open Contracting for Infrastructure Data Standards Toolkit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Charlie Pinder <charlie.pinder@opendataservices.coop>, 2019
+# Romina Fernandez <rfernandez@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Contracting for Infrastructure Data Standards Toolkit 0.9\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-14 11:34+1200\n"
+"PO-Revision-Date: 2019-03-21 15:12+0000\n"
+"Last-Translator: Romina Fernandez <rfernandez@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/97433/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../../docs/support.md:1
+msgid "Support"
+msgstr "Apoyo"
+
+#: ../../docs/support.md:3
+msgid ""
+"If you are planning to publish or use data using the OC4IDS then the OC4IDS "
+"Helpdesk team are on hand to offer advice and input."
+msgstr ""
+"Si planea publicar o usar datos que utilizan OC4IDS, el equipo del Helpdesk "
+"de OC4IDS está disponible para ofrecer consejos y sugerencias."
+
+#: ../../docs/support.md:5
+msgid "We can:"
+msgstr "Podemos:"
+
+#: ../../docs/support.md:7
+msgid ""
+"Help you identify approaches for converting data from your existing systems "
+"to OC4IDS;"
+msgstr ""
+"Ayudarte a identificar estrategias para convertir datos desde sus sistemas "
+"existentes a OC4IDS;"
+
+#: ../../docs/support.md:8
+msgid ""
+"Suggest existing tools and services which may help you publish or use OC4IDS"
+" data;"
+msgstr ""
+"Sugerir herramientas y servicios existentes que podrían ayudarte a publicar "
+"o usar datos OC4IDS;"
+
+#: ../../docs/support.md:9
+msgid "Provide guidance on mapping your data structures to the standard;"
+msgstr "Proveer guía sobre cómo mapear tus estructuras de datos al estándar;"
+
+#: ../../docs/support.md:10
+msgid ""
+"Give you feedback on draft data files, and support with validation of your "
+"data;"
+msgstr ""
+"Dar retroalimentación sobre borradores de archivos de datos y apoyo para "
+"validar tus datos;"
+
+#: ../../docs/support.md:12
+msgid ""
+"Through funding from the Open Contracting Partnership and CoST - the "
+"Infrastructure Transparency Initiative, this support is provided free of "
+"charge."
+msgstr ""
+"Gracias al financiamiento por parte de Open Contracting Partnership y CoST -"
+" la Iniciativa de Transparencia en Infraestructura, este soporte es proveído"
+" de forma gratuita."
+
+#: ../../docs/support.md:14
+msgid ""
+"E-mail [data@open-contracting.org](mailto:data@open-contracting.org) with "
+"your questions, and a member of the OC4IDS Helpdesk will be in touch with "
+"you soon."
+msgstr ""
+"Escriba un correo a [data@open-contracting.org](mailto:data@open-"
+"contracting.org) con sus preguntas, y un miembro del Helpdesk de OC4IDS se "
+"pondrá en contacto con usted."
+
+#: ../../docs/support.md:20
+msgid ""
+"Developers, or those wishing to provide technical input to OC4IDS, may wish "
+"to go straight to the [GitHub repository](https://github.com/open-"
+"contracting/infrastructure)."
+msgstr ""
+"Los desarrolladores, u otros interesados en brindar aporte técnico a OC4IDS,"
+" podrían desear ir directamente al  [repositorio de "
+"GitHub](https://github.com/open-contracting/infrastructure)."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,21 +1,21 @@
 languages = {
     'en': 'English',
-    # 'es': 'Español',
+    'es': 'Español',
 }
 
 test_basic_params = {
     'en': 'Toolkit',
-    # 'es': 'Inicio',
+    'es': 'Inicio',
 }
 
 test_navigation_params = [
     ('en', 'Next'),
-    # ('es', 'Siguiente'),
+    ('es', 'Siguiente'),
 ]
 
 test_search_params = [
     ('en', r'found \d+ page\(s\) matching'),
-    # ('es', r'encontró \d+ página\(s\) acorde'),
+    ('es', r'encontró \d+ página\(s\) acorde'),
 ]
 
 last_path = '/support/'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ languages = {
 
 test_basic_params = {
     'en': 'Toolkit',
-    'es': 'Inicio',
+    'es': 'Contrataciones',
 }
 
 test_navigation_params = [


### PR DESCRIPTION
Closes #179 

I had to remove the '-' from the gettext_domain_prefix in https://github.com/open-contracting/infrastructure/blob/pull-translations/docs/conf.py#L98 to get the translation to build.

I reviewed the built translation locally and noticed 3 untranslated elements:

* The sidebar header
* The copyright notice
* The CoST IDS mapping tables

It looks like this might be causing the test failure. I think something needs updating in the makefiles so that POT files are created for these resources. @jpmckinney can you advise?
