### PR TITLE
update link to field-level mapping template

### DIFF
--- a/docs/guidance/publishing.md
+++ b/docs/guidance/publishing.md
@@ -42,7 +42,7 @@ Map existing data structures to [OC4IDS](../../projects/index).
 
     .. markdown::
 
-      The [OC4IDS Field-Level Mapping Template](https://docs.google.com/spreadsheets/d/1xHLf_w193pp97zfzhLc_LI-yEXrR_eyscga06Qo1blk/copy) can be used to document your mapping.
+      The [OC4IDS Field-Level Mapping Template](https://www.open-contracting.org/resources/oc4ids-field-level-mapping-template/) can be used to document your mapping.
 
 ```
 


### PR DESCRIPTION
Camila pointed out that https://standard.open-contracting.org/infrastructure/latest/en/guidance/publishing/ links directly to an old version of the mapping template, rather than to the resource published on the OCP website.

This was fixed in https://github.com/open-contracting/infrastructure/pull/121/commits/d13fe0e49c3b90d45875510076175ecaba91811a and the new link is present on the 0.9 branch, so I'm not sure why the link is not updated in either the current version of the docs, or in the 0.9-dev branch. Especially as the other changes in that commit are present.

According to https://github.com/open-contracting/infrastructure/compare/0.9-dev...0.9 0.9-dev is up to date with all commits from 0.9, so I don't think we're missing anything else, but then this discrepancy isn't reflected there either. @jpmckinney any ideas what might be going on here?