### PR TITLE
Update changelog + remove 'finalAudit' code

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -57,7 +57,8 @@ Added:
 
 Removed:
 
-* [#269](https://github.com/open-contracting/infrastructure/issues/269) 'finalAudit'
+* [#269](https://github.com/open-contracting/infrastructure/issues/269) 'finalAudit' (use 'technicalAuditReport' or 'financialAuditReport')
+* [#321](https://github.com/open-contracting/infrastructure/issues/269) 'contractSchedule' (use 'contractAnnexe')
 
 ## [0.9.2] - 2020-06-29
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,28 +1,29 @@
 # Changelog
 
-## [X.X.X] - YYYY-MM-DD
+## [0.9.3] - 2021-04-30
 
 ### Documentation
 
 * [#210](https://github.com/open-contracting/infrastructure/issues/210):
-  * update the 'Mapping from OCDS' column to reflect the logic used in [convert-to-oc4ids](https://ocdskit.readthedocs.io/en/latest/cli/ocds.html#convert-to-oc4ids)
+  * update the 'Mapping from OCDS' column to reflect the logic used in [convert-to-oc4ids](https://ocdskit.readthedocs.io/en/latest/cli/ocds.html#convert-to-oc4ids).
   * remove references to the PPP profile, reference individual extensions instead.
-  * update project identification mapping for sector
-  * replace reference to Budget and projects extension with Projects extension
-  * remove reference to 'publicAuthority' code from OCDS mapping
+  * update project identification mapping for sector.
+  * replace reference to Budget and projects extension with Projects extension.
+  * remove reference to 'publicAuthority' code from OCDS mapping.
 * [#216](https://github.com/open-contracting/infrastructure/issues/216) - update CoST IDS & OCDS mapping documentation to separate the OC4IDS to CoST IDS mapping and the OCDS to OC4IDS mapping.
 * [#217](https://github.com/open-contracting/infrastructure/issues/217) - remove repeated 'OCDS:' in mapping documentation.
 * [#220](https://github.com/open-contracting/infrastructure/issues/220) - add reactive disclosure elements to CoST IDS & OCDS mapping documentation.
-* [#246](https://github.com/open-contracting/infrastructure/issues/246) - correct link and wording to Project extension in project identifiers guidance
+* [#246](https://github.com/open-contracting/infrastructure/issues/246) - correct link and wording to Project extension in project identifiers guidance.
 * [#268](https://github.com/open-contracting/infrastructure/issues/268), [#269](https://github.com/open-contracting/infrastructure/issues/269) replace 'finalAudit' with 'technicalAuditReport' and 'financialAuditReport' in mapping.
-* [#278](https://github.com/open-contracting/infrastructure/issues/278) - Add reactive disclosures to worked example.
-* [#304](https://github.com/open-contracting/infrastructure/issues/304) update blank OC4IDS file with schema changes, and add project package. 
-* [#316](https://github.com/open-contracting/infrastructure/issues/316) update wording around worked example file, add link to blank.json.
+* [#278](https://github.com/open-contracting/infrastructure/issues/278) - add reactive disclosures to worked example.
+* [#304](https://github.com/open-contracting/infrastructure/issues/304) - update blank OC4IDS file with schema changes, and add project package.
+* [#316](https://github.com/open-contracting/infrastructure/issues/316) - update wording around worked example file, add link to blank.json.
+* [#260](https://github.com/open-contracting/infrastructure/pull/260) - improve the clarity of the Getting Started documentation.
 
 ### Schema
 
 * [#277](https://github.com/open-contracting/infrastructure/issues/277) - add `forecasts` and `metrics`, which can be used to publish implementation progress reports.
-* [#282](https://github.com/open-contracting/infrastructure/pull/282) - update fields shared with OCDS for PPPs 1.0.0-beta2 and OCDS 1.1.4.
+* [#317](https://github.com/open-contracting/infrastructure/pull/317) - update fields shared with OCDS for PPPs 1.0.0-beta3 and OCDS 1.1.5.
 * [#264](https://github.com/open-contracting/infrastructure/issues/264) - add a field and class for natural persons.
 * [#273](https://github.com/open-contracting/infrastructure/issues/273) - add `contractingProcesses/summary/transactions`, which can be used to publish disbursement records.
 * [#284](https://github.com/open-contracting/infrastructure/issues/284) - restore `classification/uri` field.
@@ -30,7 +31,7 @@
 
 ### Codelists
 
-* [#282](https://github.com/open-contracting/infrastructure/pull/282) - update codes shared with OCDS for PPPs 1.0.0-beta2 and OCDS 1.1.4.
+* [#317](https://github.com/open-contracting/infrastructure/pull/317) - update codes shared with OCDS for PPPs 1.0.0-beta3 and OCDS 1.1.5.
 
 #### documentType codelist
 
@@ -56,7 +57,7 @@ Added:
 
 Removed:
 
-* [#268](https://github.com/open-contracting/infrastructure/issues/268) 'finalAudit'
+* [#269](https://github.com/open-contracting/infrastructure/issues/269) 'finalAudit'
 
 ## [0.9.2] - 2020-06-29
 

--- a/schema/borrow-schema.py
+++ b/schema/borrow-schema.py
@@ -233,13 +233,11 @@ ignore = {
     'finalAudit',
     # https://github.com/open-contracting/standard/issues/870
     'contractSchedule',
-    # PPP-specific
+    # PPP-specific code or description
     'needsAssessment',
     'projectAdditionality',
     'financeAdditionality',
     'pppModeRationale',
-    'contractSchedule',
-    'riskProvisions',
     'riskComparison',
     'discountRate',
     'equityTransferCaps',
@@ -297,7 +295,7 @@ for basename in ocds_codelists:
             # Add codes from OCDS.
             reader = csv_reader(f'{ocds_base_url}codelists/documentType.csv')
             for row in reader:
-                if row['Code'] not in seen and row['Code'] != 'finalAudit':
+                if row['Code'] not in seen and row['Code'] not in ignore:
                     seen.append(row['Code'])
                     edit_code(row, oc4ids_codes, 'OCDS')
                     writer.writerow(row)

--- a/schema/borrow-schema.py
+++ b/schema/borrow-schema.py
@@ -228,7 +228,36 @@ compare(schema['definitions'], infra_definitions, ocds_definitions,
         'schema/project-level/project-schema.json#/definitions', 'definitions')
 
 # https://docs.google.com/spreadsheets/d/1ttXgMmmLvqBlPRi_4jAJhIobjnCiwMv13YwGfFOnoJk/edit#gid=0
-document_type_csv_url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS1VCdsV-Xwvsh6QnK2z9lcpLRyfc472dtpFTicS8C6Yul2MONPYw08lBLd8j55mnerjya9T4qCiekT/pub?gid=0&single=true&output=csv'  # noqa: E501
+ignore = {
+    # https://github.com/open-contracting/infrastructure/issues/269
+    'finalAudit',
+    # https://github.com/open-contracting/standard/issues/870
+    'contractSchedule',
+    # PPP-specific
+    'needsAssessment',
+    'projectAdditionality',
+    'financeAdditionality',
+    'pppModeRationale',
+    'contractSchedule',
+    'riskProvisions',
+    'riskComparison',
+    'discountRate',
+    'equityTransferCaps',
+    'financeArrangements',
+    'guaranteeReports',
+    'grants',
+    'servicePayments',
+    'landTransfer',
+    'assetTransfer',
+    'revenueShare',
+    'otherGovernmentSupport',
+    'tariffMethod',
+    'tariffReview',
+    'tariffs',
+    'tariffIllustration',
+    'handover',
+    'financialStatement',
+}
 
 # Copy the OCDS codelists.
 for basename in ocds_codelists:
@@ -252,12 +281,6 @@ for basename in ocds_codelists:
             writer = csv.DictWriter(io, fieldnames, lineterminator='\n', extrasaction='ignore')
             writer.writeheader()
             seen = []
-
-            # Find which codes from OCDS for PPPs to ignore.
-            reader = csv_reader(document_type_csv_url)
-            ignore = [row['Code'] for row in reader if row['PPP specific?']]
-            ignore.append('contractSchedule')
-            ignore.append('finalAudit')
 
             # Add codes from OCDS for PPPs.
             reader = csv_reader(f'{ppp_base_url}codelists/{basename}')

--- a/schema/borrow-schema.py
+++ b/schema/borrow-schema.py
@@ -257,6 +257,7 @@ for basename in ocds_codelists:
             reader = csv_reader(document_type_csv_url)
             ignore = [row['Code'] for row in reader if row['PPP specific?']]
             ignore.append('contractSchedule')
+            ignore.append('finalAudit')
 
             # Add codes from OCDS for PPPs.
             reader = csv_reader(f'{ppp_base_url}codelists/{basename}')
@@ -273,7 +274,7 @@ for basename in ocds_codelists:
             # Add codes from OCDS.
             reader = csv_reader(f'{ocds_base_url}codelists/documentType.csv')
             for row in reader:
-                if row['Code'] not in seen:
+                if row['Code'] not in seen and row['Code'] != 'finalAudit':
                     seen.append(row['Code'])
                     edit_code(row, oc4ids_codes, 'OCDS')
                     writer.writerow(row)

--- a/schema/project-level/codelists/documentType.csv
+++ b/schema/project-level/codelists/documentType.csv
@@ -14,7 +14,6 @@ contractSigned,Signed contract,"A copy of the signed contract. Consider providin
 contractArrangements,Arrangements for ending contract,Documentation of the arrangements for ending the contract(s).,OCDS for PPPs
 physicalProgressReport,Physical progress reports,"Documentation on the status of implementation, usually against key milestones.",OCDS for PPPs
 financialProgressReport,Financial progress reports,"Documentation providing dates and amounts of stage payments made (against total amount) and the source of those payments, including cost overruns, if any. Structured versions of this information can be provided through contract implementation transactions.",OCDS for PPPs
-finalAudit,Final audit,Documentation of a final audit carried out at the end of contract implementation.,OCDS for PPPs
 hearingNotice,Public hearing notice,Documentation of any public hearings that took place as part of the planning for this contracting process.,OCDS for PPPs
 marketStudies,Market studies,Documentation of any market studies that took place as part of the planning for this contracting process.,OCDS for PPPs
 eligibilityCriteria,Eligibility criteria,Detailed documents about the eligibility of bidders.,OCDS for PPPs

--- a/schema/project-level/codelists/documentType.csv
+++ b/schema/project-level/codelists/documentType.csv
@@ -21,6 +21,7 @@ clarifications,Clarifications to bidders questions,Documentation that provides r
 shortlistedFirms,Shortlisted firms,Documentation providing information on shortlisted firms. Structured versions of this information can be provided using the bids extension.,OCDS for PPPs
 environmentalImpact,Environmental impact assessment,"Documentation of assessments of the environmental impacts (e.g. impacts on flora, fauna & woodlands, areas of natural beauty, carbon emissions etc.) and mitigation measures (e.g. pollution control, low carbon solutions, sustainable timber etc.) for this contracting process or project.",OC4IDS
 assetAndLiabilityAssessment,Assessment of government's assets and liabilities,Documentation covering assessments of the government's assets and liabilities related to this contracting process.,OCDS for PPPs
+riskProvisions,Provisions for management of risks and liabilities,Documentation covering how risks will be managed as part of this contracting process.,OCDS for PPPs
 winningBid,Winning bid,"Documentation of the winning bid, including, wherever applicable, a full copy of the proposal received.",OCDS for PPPs
 complaints,Complaints and decisions,"Documentation of any complaints received, or decisions in response to complaints.",OCDS for PPPs
 contractAnnexe,Annexes to the contract,Copies of annexes and other supporting documentation related to the contract.,OCDS for PPPs
@@ -46,8 +47,6 @@ negotiationParameters,Negotiation parameters,A description of the parameters for
 defaultEvents,Defaults,Information on events of default,OCDS for PPPs
 termination,Termination,Information on contract termination,OCDS for PPPs
 performanceReport,Performance report,Performance assessment reports,OCDS for PPPs
-contractSchedule,Contract schedules,"Any document which contains additional terms, obligations or information related to the contract, such as a schedule, appendix, annex, attachment or addendum.",OCDS
-riskProvisions,Provisions for management of risks and liabilities,Documentation covering how risks will be managed as part of this contracting process.,OCDS
 needsAssessment,Needs assessment,Documentation of the needs assessments carried out for this contracting process or project addressing demand for the project or investment from the affected communities or users.,OC4IDS
 socialImpact,Social impact assessment,"Documentation of assessments of the intended and unintended social consequences of this project, and documentation of mitigation measures for those social consequences. Social impacts are changes that affect people, directly or indirectly (e.g. changes to people's way of life, culture, community, health and well-being etc.).",OC4IDS
 landAndSettlementImpact,Land and settlement impact assessment,"State the amount of land and property that was acquired for the project (e.g. 25sq km land), and outline related impacts (e.g. archaeological issues (moved Saxon burial site), local/indigenous settlements (relocated 5 indigenous villages of 500 villagers each), impacts on local businesses e.g. (30 business properties purchased)).",OC4IDS


### PR DESCRIPTION
@jpmckinney whilst preparing the mailing list post for OC4IDS 0.9.3 I noticed a couple of missing changelog entries and I realised that we agreed to remove the 'finalAudit' code that was added back in #317 