### PR TITLE
Changing links to point to extension explorer

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -56,7 +56,7 @@ When working with data, users should be aware that addresses may not always be b
 
 A budget breakdown is provided through an array of `BudgetBreakdown` objects, each of which represents budget for a particular period, from a particular source, or a combination of the two.
 
-See the [documentation of the OCDS Budget Breakdown extension](https://github.com/open-contracting-extensions/ocds_budget_breakdown_extension) for more details of this data model. BudgetBreakdown can also be extended further to include budget classifications data following the pattern described in the [OCDS Budgets and Spend extension](https://github.com/open-contracting-extensions/ocds_budget_and_spend_extension).
+See the [documentation of the OCDS Budget Breakdown extension](https://extensions.open-contracting.org/en/extensions/budget/master/) for more details of this data model. BudgetBreakdown can also be extended further to include budget classifications data following the pattern described in the [OCDS Budgets and Spend extension](https://extensions.open-contracting.org/en/extensions/budget_and_spend/master/).
 
 ```{jsonschema} ../../build/current_lang/project-schema.json
 :pointer: /definitions/BudgetBreakdown


### PR DESCRIPTION
I've checked through the standard site and changed any extension links to point to the extension explorer as described in #330.