### PR TITLE
include/common.mk: Ignore docs/_static directory in make autobuild

### DIFF
--- a/include/common.mk
+++ b/include/common.mk
@@ -121,7 +121,7 @@ all: build_source compile $(TRANSLATIONS:.%=build.%) clean_current_lang
 
 .PHONY: autobuild
 autobuild: current_lang.en
-	sphinx-autobuild -nW -q -b dirhtml $(DOCS_DIR) $(BUILD_DIR)/en
+	sphinx-autobuild --re-ignore $(DOCS_DIR)/_static.* -nW -q -b dirhtml $(DOCS_DIR) $(BUILD_DIR)/en
 
 .PHONY: update
 update: clean_dist

--- a/include/common.mk
+++ b/include/common.mk
@@ -121,7 +121,7 @@ all: build_source compile $(TRANSLATIONS:.%=build.%) clean_current_lang
 
 .PHONY: autobuild
 autobuild: current_lang.en
-	sphinx-autobuild --re-ignore $(DOCS_DIR)/_static.* -nW -q -b dirhtml $(DOCS_DIR) $(BUILD_DIR)/en
+	sphinx-autobuild $(SPHINX_AUTOBUILD_EXTRA_ARGS) -nW -q -b dirhtml $(DOCS_DIR) $(BUILD_DIR)/en
 
 .PHONY: update
 update: clean_dist

--- a/include/config.mk
+++ b/include/config.mk
@@ -23,7 +23,7 @@ DOMAIN_PREFIX=infrastructure-
 TRANSIFEX_PROJECT=oc4ids-09
 # Any additional extract targets.
 EXTRACT_TARGETS=extract_mappings
-# Extra arguments for sphinx-autobuild
+# Extra arguments for sphinx-autobuild.
 SPHINX_AUTOBUILD_EXTRA_ARGS=--re-ignore $(DOCS_DIR)/_static.*
 
 # The path to the branch of the documentation to print to PDF.

--- a/include/config.mk
+++ b/include/config.mk
@@ -23,6 +23,8 @@ DOMAIN_PREFIX=infrastructure-
 TRANSIFEX_PROJECT=oc4ids-09
 # Any additional extract targets.
 EXTRACT_TARGETS=extract_mappings
+# Extra arguments for sphinx-autobuild
+SPHINX_AUTOBUILD_EXTRA_ARGS=--re-ignore $(DOCS_DIR)/_static.*
 
 # The path to the branch of the documentation to print to PDF.
 PDF_ROOT=/infrastructure/latest


### PR DESCRIPTION
Prior to this change, `make autobuild` gets stuck in an infinite loop because it detects a change in `docs/_static/project-level/project-level-completion.csv`.