### PR TITLE
Adding budget/description to json example

### DIFF
--- a/docs/examples/blank.json
+++ b/docs/examples/blank.json
@@ -60,6 +60,7 @@
     }
   ],
   "budget": {
+    "description": "",
     "amount": {
       "amount": "number",
       "currency": "string from currency codelist"

--- a/docs/examples/example.json
+++ b/docs/examples/example.json
@@ -102,6 +102,7 @@
         }
       ],
       "budget": {
+        "description": "Budget allocation for Motorways UK, aligned with the 2016-2018 strategic plan.",
         "amount": {
           "amount": 40000000,
           "currency": "GBP"

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -15,10 +15,9 @@
 
 * [#355](https://github.com/open-contracting/infrastructure/pull/355) - use correct normative and non-normative keywords in schema descriptions.
 * [#361](https://github.com/open-contracting/infrastructure/pull/361) - clarify project budget description.
-* [#365](https://github.com/open-contracting/infrastructure/pull/365) - add description field to budget.
+* [#365](https://github.com/open-contracting/infrastructure/pull/365) [#386](https://github.com/open-contracting/infrastructure/pull/386) - add description field to budget.
 * [#367](https://github.com/open-contracting/infrastructure/pull/367) - add approval date to budget breakdown.
 * [#368](https://github.com/open-contracting/infrastructure/pull/368) - clarify contracting processes id description.
-* [#386](https://github.com/open-contracting/infrastructure/pull/386) - add example for description field in budget.
 
 ### Codelists
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -18,6 +18,7 @@
 * [#365](https://github.com/open-contracting/infrastructure/pull/365) - add description field to budget.
 * [#367](https://github.com/open-contracting/infrastructure/pull/367) - add approval date to budget breakdown.
 * [#368](https://github.com/open-contracting/infrastructure/pull/368) - clarify contracting processes id description.
+* [#386](https://github.com/open-contracting/infrastructure/pull/386) - add example for description field in budget.
 
 ### Codelists
 


### PR DESCRIPTION
**Related issues**

Closes #336
Completes work started in #365

**Description**

Adding budget/description field to blank and example json

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] [Log your changes](https://ocds-standard-development-handbook.readthedocs.io/en/latest/standard/contributing.html#logging-changes)

If there are changes to `project-schema.json` or `project-package-schema.json`:

- [x] Update the examples:
  - [x] `docs/examples/example.json`
  - [x] `docs/examples/blank.json`
- [ ] Run `./manage.py pre-commit` to update `docs/_static/i8n.csv`

If you added a new definition to the schema, update `docs/reference/schema.md`:

- [ ] Add an entry to the components section
- [ ] Update the `:collapse:` parameter of the `jsonschema` directive for any schemas or sub-schemas that reference the new definition 

If you added a new codelist:

  - [ ] Add an entry to `docs/reference/codelists.md`