### PR TITLE
docs: Translate CoST IDS titles and definitions

### DIFF
--- a/babel_ocds_mapping.cfg
+++ b/babel_ocds_mapping.cfg
@@ -1,3 +1,2 @@
 [ocds_codelist: mapping/*.csv]
-# "CoST IDS element" and "CoST IDS draft definition" are from CoST IDS and are not translated.
-headers = Mapping to OC4IDS,Mapping from OCDS
+headers = CoST IDS element,CoST IDS draft definition,Mapping to OC4IDS,Mapping from OCDS

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ def setup(app):
     # Headers for columns to translate in codelist CSVs. The headers in babel_ocds_mapping.cfg should match these.
     codelist_headers = ['Title', 'Description', 'Extension']
     # Headers for columns to translate in mapping CSVs. The headers in babel_ocds_mapping.cfg should match these.
-    mapping_headers = ['Mapping to OC4IDS', 'Mapping from OCDS']
+    mapping_headers = ['CoST IDS element', 'CoST IDS draft definition', 'Mapping to OC4IDS', 'Mapping from OCDS']
 
     # The gettext domain for schema translations. Should match the domain in the `pybabel compile` command.
     schema_domain = f'{gettext_domain_prefix}schema'

--- a/include/config.mk
+++ b/include/config.mk
@@ -21,6 +21,8 @@ POT_DIR=$(BUILD_DIR)/locale
 DOMAIN_PREFIX=infrastructure-
 # The Transifex project name.
 TRANSIFEX_PROJECT=oc4ids-09
+# The Transifex organization name.
+TRANSIFEX_ORGANIZATION=open-contracting-partnership-1
 # Any additional extract targets.
 EXTRACT_TARGETS=extract_mappings
 # Extra arguments for sphinx-autobuild.


### PR DESCRIPTION
**Related issues**

* #467

**Description**

I've pushed the newly extracted strings to Transifex:

![image](https://github.com/open-contracting/infrastructure/assets/19265814/feaa9205-5908-4981-b30b-c580f972b26d)

Not sure if this needs a changelog entry