### PR TITLE
Fix typo in sustainability modules mapping, fix pre-commit script

### DIFF
--- a/docs/cost/ids/sustainability.md
+++ b/docs/cost/ids/sustainability.md
@@ -1097,7 +1097,7 @@ Disclose the financial instrument type from the list:
 :columns: 8
 OC4IDS mapping
 ^^^
-1. Get the [`Finance`](../../reference/schema.md#finance) object in [`.udget.finance`](project-schema.json,,budget/finance) or [`contractingProcesses.summary.finance`](project-schema.json,/definitions/ContractingProcessSummary,finance) that represents the financing arrangement. If none exists yet, [add a financing arrangement](../common.md#add-a-financing-arrangement).
+1. Get the [`Finance`](../../reference/schema.md#finance) object in [`.budget.finance`](project-schema.json,,budget/finance) or [`contractingProcesses.summary.finance`](project-schema.json,/definitions/ContractingProcessSummary,finance) that represents the financing arrangement. If none exists yet, [add a financing arrangement](../common.md#add-a-financing-arrangement).
 2. Set the the financing arrangement's [`.assetClass`](project-schema.json,/definitions/Finance,assetClass) and [`.type`](project-schema.json,/definitions/Finance,type) according to the instrument type:
 
 Instrument type | [`.assetClass`](project-schema.json,/definitions/Finance,assetClass) | [`.type`](project-schema.json,/definitions/Finance,type)

--- a/manage.py
+++ b/manage.py
@@ -144,7 +144,7 @@ def pre_commit():
 
         if "properties" in schema:
             for key, value in schema["properties"].items():
-                if value.get("type") in {"array", ["array"]} and "$ref" in value["items"]:
+                if value.get("type") in ["array", ["array"]] and "$ref" in value["items"]:
                     if value["items"]["$ref"] == f"#/definitions/{defn}":
                         references.append([*parents, key, "0"])
                     elif include_nested:
@@ -249,7 +249,7 @@ def pre_commit():
             # Add schema table
             properties_to_collapse = []
             for key, value in definition["properties"].items():
-                if value.get("type") not in {"object", ["object"]}:
+                if value.get("type") not in ["object", ["object"]]:
                     properties_to_collapse.append(key)
 
             definition["content"].extend(

--- a/mapping/sustainability.yaml
+++ b/mapping/sustainability.yaml
@@ -924,7 +924,7 @@
         - equity
         - guarantees
     mapping: |-
-        1. Get the [`Finance`](../../reference/schema.md#finance) object in [`.udget.finance`](project-schema.json,,budget/finance) or [`contractingProcesses.summary.finance`](project-schema.json,/definitions/ContractingProcessSummary,finance) that represents the financing arrangement. If none exists yet, [add a financing arrangement](../common.md#add-a-financing-arrangement).
+        1. Get the [`Finance`](../../reference/schema.md#finance) object in [`.budget.finance`](project-schema.json,,budget/finance) or [`contractingProcesses.summary.finance`](project-schema.json,/definitions/ContractingProcessSummary,finance) that represents the financing arrangement. If none exists yet, [add a financing arrangement](../common.md#add-a-financing-arrangement).
         2. Set the the financing arrangement's [`.assetClass`](project-schema.json,/definitions/Finance,assetClass) and [`.type`](project-schema.json,/definitions/Finance,type) according to the instrument type:
 
         Instrument type | [`.assetClass`](project-schema.json,/definitions/Finance,assetClass) | [`.type`](project-schema.json,/definitions/Finance,type)


### PR DESCRIPTION
@jpmckinney, the pre-commit script was failing with an unhashable type error as a result of https://github.com/open-contracting/infrastructure/commit/778d25947378f6b3f7f89c08b13b83cf133b7393. So, this PR reverts to using lists for inclusion conditions with unhashable types. I'm not sure if there's another way around that.